### PR TITLE
Add to album option in file viewer

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/file_app_bar.dart
@@ -220,6 +220,19 @@ class FileAppBarState extends State<FileAppBar> {
         ),
       );
     }
+    // Add to album option for uploaded files (behind feature flag)
+    if (flagService.addToAlbumFeature &&
+        widget.file.isUploaded &&
+        !isFileHidden) {
+      items.add(
+        EntePopupMenuItem(
+          "+ (i)",
+          value: 10,
+          icon: Icons.add,
+          iconColor: Theme.of(context).iconTheme.color,
+        ),
+      );
+    }
     if ((widget.file.fileType == FileType.image ||
             widget.file.fileType == FileType.livePhoto) &&
         Platform.isAndroid) {
@@ -360,6 +373,8 @@ class FileAppBarState extends State<FileAppBar> {
               await _handleVideoStream('create');
             } else if (value == 9) {
               await _handleVideoStream('recreate');
+            } else if (value == 10) {
+              await _handleAddToAlbum();
             }
           },
         ),
@@ -528,5 +543,15 @@ class FileAppBarState extends State<FileAppBar> {
       _logger.severe("Failed to $streamType video stream", e, s);
       await showGenericErrorDialog(context: context, error: e);
     }
+  }
+
+  Future<void> _handleAddToAlbum() async {
+    final selectedFiles = SelectedFiles();
+    selectedFiles.files.add(widget.file);
+    showCollectionActionSheet(
+      context,
+      selectedFiles: selectedFiles,
+      actionType: CollectionActionType.addFiles,
+    );
   }
 }

--- a/mobile/apps/photos/lib/ui/viewer/file_details/albums_item_widget.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file_details/albums_item_widget.dart
@@ -7,7 +7,10 @@ import "package:photos/generated/l10n.dart";
 import 'package:photos/models/collection/collection.dart';
 import 'package:photos/models/collection/collection_items.dart';
 import 'package:photos/models/file/file.dart';
+import "package:photos/models/selected_files.dart";
+import "package:photos/service_locator.dart";
 import "package:photos/services/collections_service.dart";
+import "package:photos/ui/collections/collection_action_sheet.dart";
 import "package:photos/ui/components/buttons/chip_button_widget.dart";
 import "package:photos/ui/components/info_item_widget.dart";
 import "package:photos/ui/viewer/gallery/collection_page.dart";
@@ -101,6 +104,25 @@ class AlbumsItemWidget extends StatelessWidget {
           ),
         );
       }
+
+      // Add the '+' button if feature flag is enabled
+      if (flagService.addToAlbumFeature) {
+        chipButtons.add(
+          ChipButtonWidget(
+            "+ (i)",
+            onTap: () {
+              final selectedFiles = SelectedFiles();
+              selectedFiles.files.add(file);
+              showCollectionActionSheet(
+                context,
+                selectedFiles: selectedFiles,
+                actionType: CollectionActionType.addFiles,
+              );
+            },
+          ),
+        );
+      }
+
       return chipButtons;
     } catch (e, s) {
       Logger("AlbumsItemWidget").info(e, s);

--- a/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
+++ b/mobile/apps/photos/plugins/ente_feature_flag/lib/src/service.dart
@@ -66,6 +66,8 @@ class FlagService {
 
   bool get albumGuestView => internalUser;
 
+  bool get addToAlbumFeature => internalUser;
+
   bool hasSyncedAccountFlags() {
     return _prefs.containsKey("remote_flags");
   }
@@ -114,10 +116,7 @@ class FlagService {
     try {
       final response = await _enteDio.post(
         "/remote-store/update",
-        data: {
-          "key": key,
-          "value": value,
-        },
+        data: {"key": key, "value": value},
       );
       if (response.statusCode != HttpStatus.ok) {
         throw Exception("Unexpected state");

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,3 +1,4 @@
+- Neeraj: (i) Add to album option in file overflow menu and file details [#3291](https://github.com/ente-io/ente/discussions/3291)
 - Neeraj: (i) Add collection-level guest view option in album overflow menu
 - Neeraj: Fix IDN domain display in public URLs [#7079](https://github.com/ente-io/ente/issues/7079)
 - Neeraj: (i) Add allow joining album option in manage links


### PR DESCRIPTION
## Summary
- Added "Add to album" option in file overflow menu and file details
- Feature is behind internal user flag

## Test plan
- Open any photo/video file
- Check overflow menu has "+ (i)" option before "Set as"
- Check file details Albums section has "+ (i)" chip button
- Tapping either opens album selection sheet

Co-Authored-By: Claude <noreply@anthropic.com>