### PR TITLE
Fix iOS portrait video aspect ratio being squeezed into landscape

### DIFF
--- a/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
+++ b/mobile/apps/photos/lib/ui/viewer/file/video_widget_native.dart
@@ -802,7 +802,11 @@ class _VideoWidgetNativeState extends State<VideoWidgetNative>
       await metadataController.initialize().timeout(const Duration(seconds: 4));
       final value = metadataController.value;
       final probeAspectRatio = value.aspectRatio;
-      if ((aspectRatio == null || aspectRatio == 1) && probeAspectRatio > 0) {
+      // Always prefer the probed aspect ratio over file metadata dimensions,
+      // because AVPlayer correctly accounts for video rotation metadata.
+      // Raw file width/height may not reflect rotation (e.g. a portrait video
+      // stored as 1920x1080 with 90° rotation).
+      if (probeAspectRatio > 0) {
         aspectRatio = probeAspectRatio;
       }
       final durationInMilliseconds = value.duration.inMilliseconds;


### PR DESCRIPTION
The iOS AVPlayer probe correctly handles video rotation metadata, but
its result was only used when the existing aspect ratio was null or 1.
When file metadata dimensions were available (which don't account for
rotation), the correct probed ratio was silently discarded. Always
prefer the probed aspect ratio since AVPlayer handles rotation.

