### PR TITLE
[mobile][photos] Guard home widget file metadata

### DIFF
--- a/mobile/apps/photos/lib/services/home_widget_service.dart
+++ b/mobile/apps/photos/lib/services/home_widget_service.dart
@@ -147,6 +147,9 @@ class HomeWidgetService {
     int? uploadedFileID,
   ) async {
     try {
+      if (file.creationTime == null || file.generatedID == null) {
+        return false;
+      }
       // Get thumbnail data
       final thumbnail = await getThumbnail(file);
       if (thumbnail == null) {


### PR DESCRIPTION
Fixes PHOTOS-MOBILE-H95.
Fixes PHOTOS-MOBILE-F96.