### PR TITLE
Harden Space sessions, post limits, and asset cleanup

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -981,6 +981,7 @@ func main() {
 	spaceRepos := spacerepo.NewModule(db, s3Config)
 	userController.SpaceAccessResetter = spaceRepos
 	spaceModule := spacecontroller.NewModule(spaceRepos, userAuthRepo, &spacecontroller.SpaceEmailSender{UserRepo: userRepo})
+	spaceModule.Posts.AbuseNotifier = discordController
 	spaceDripController := spacecontroller.NewSpaceDripController(spaceRepos, userRepo, notificationHistoryRepo, lockController)
 	spaceModule.UserTokens = userController
 	spaceHandlers := spaceapi.NewHandlers(spaceModule)

--- a/server/pkg/controller/user/srp.go
+++ b/server/pkg/controller/user/srp.go
@@ -90,6 +90,12 @@ func (c *UserController) UpdateSrpAndKeyAttributes(context *gin.Context,
 		if err != nil {
 			return nil, err
 		}
+		if c.SpaceAccessResetter != nil {
+			err = c.SpaceAccessResetter.RevokeBrowserSessions(context.Request.Context(), userID)
+			if err != nil {
+				return nil, err
+			}
+		}
 	} else {
 		logrus.WithField("user_id", userID).Info("not clearing tokens")
 	}

--- a/server/pkg/controller/user/srp.go
+++ b/server/pkg/controller/user/srp.go
@@ -90,11 +90,9 @@ func (c *UserController) UpdateSrpAndKeyAttributes(context *gin.Context,
 		if err != nil {
 			return nil, err
 		}
-		if c.SpaceAccessResetter != nil {
-			err = c.SpaceAccessResetter.RevokeBrowserSessions(context.Request.Context(), userID)
-			if err != nil {
-				return nil, err
-			}
+		err = c.SpaceAccessResetter.RevokeBrowserSessions(context, userID)
+		if err != nil {
+			return nil, err
 		}
 	} else {
 		logrus.WithField("user_id", userID).Info("not clearing tokens")

--- a/server/pkg/controller/user/user.go
+++ b/server/pkg/controller/user/user.go
@@ -37,6 +37,7 @@ import (
 
 type SpaceAccessResetter interface {
 	ResetUserAccess(ctx context.Context, userID int64) error
+	RevokeBrowserSessions(ctx context.Context, userID int64) error
 }
 
 type SpaceAccountDeletionAccessResetter interface {

--- a/server/pkg/controller/user/user.go
+++ b/server/pkg/controller/user/user.go
@@ -334,6 +334,12 @@ func (c *UserController) handleAccountDeletion(
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "")
 	}
+	if c.SpaceAccessResetter != nil {
+		logger.Info("revoke space browser sessions for user")
+		if err := c.SpaceAccessResetter.RevokeBrowserSessions(ctx, userID); err != nil {
+			return nil, stacktrace.Propagate(err, "")
+		}
+	}
 
 	user, err := c.UserRepo.Get(userID)
 	if err != nil {

--- a/server/pkg/controller/user/user.go
+++ b/server/pkg/controller/user/user.go
@@ -334,11 +334,9 @@ func (c *UserController) handleAccountDeletion(
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "")
 	}
-	if c.SpaceAccessResetter != nil {
-		logger.Info("revoke space browser sessions for user")
-		if err := c.SpaceAccessResetter.RevokeBrowserSessions(ctx, userID); err != nil {
-			return nil, stacktrace.Propagate(err, "")
-		}
+	logger.Info("revoke space browser sessions for user")
+	if err := c.SpaceAccessResetter.RevokeBrowserSessions(ctx, userID); err != nil {
+		return nil, stacktrace.Propagate(err, "")
 	}
 
 	user, err := c.UserRepo.Get(userID)

--- a/server/space/api/sessions.go
+++ b/server/space/api/sessions.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ente/museum/space/controller"
 	"github.com/ente/museum/space/models"
 	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
 )
 
 func (h *Handlers) RequireSpaceBrowserSession() gin.HandlerFunc {
@@ -50,17 +51,15 @@ func (h *Handlers) CreateBrowserSession(c *gin.Context) {
 		respondJSON(c, nil, ente.ErrAuthenticationRequired)
 		return
 	}
-	created, err := h.Module.Sessions.CreateBrowserSession(c, userID, req.SessionWrapKey)
+	token := strings.TrimSpace(auth.GetToken(c))
+	created, err := h.Module.Sessions.CreateBrowserSession(c, userID, token, req.SessionWrapKey)
 	if err != nil {
 		respondJSON(c, nil, err)
 		return
 	}
-	if token := strings.TrimSpace(auth.GetToken(c)); token != "" {
-		if h.Module.UserTokens != nil {
-			if err := h.Module.UserTokens.TerminateSession(userID, token); err != nil {
-				respondJSON(c, nil, err)
-				return
-			}
+	if h.Module.UserTokens != nil {
+		if err := h.Module.UserTokens.TerminateSession(userID, token); err != nil {
+			log.WithError(err).WithField("user_id", userID).Warn("Failed to evict exchanged Space bootstrap token")
 		}
 	}
 	respondJSON(c, created.Response, nil)
@@ -74,6 +73,6 @@ func (h *Handlers) BootstrapBrowserSession(c *gin.Context) {
 
 func (h *Handlers) DeleteBrowserSession(c *gin.Context) {
 	sessionToken := strings.TrimSpace(c.GetHeader(controller.SpaceBrowserSessionTokenHeader))
-	err := h.Module.Sessions.RevokeBrowserSession(c, sessionToken)
+	err := h.Module.Sessions.RevokeBrowserSessions(c, sessionToken)
 	respondStatus(c, err)
 }

--- a/server/space/api/sessions_test.go
+++ b/server/space/api/sessions_test.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"testing"
 
+	"github.com/ente/museum/ente"
 	"github.com/ente/museum/internal/testutil"
 	baserepo "github.com/ente/museum/pkg/repo"
 	timeutil "github.com/ente/museum/pkg/utils/time"
@@ -18,6 +20,12 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
+
+type failingUserTokenTerminator struct{}
+
+func (failingUserTokenTerminator) TerminateSession(int64, string) error {
+	return errors.New("cache eviction failed")
+}
 
 func setupSpaceSessionAPITest(t *testing.T) (*Handlers, *spacerepo.Module, int64) {
 	t.Helper()
@@ -43,12 +51,16 @@ func setupSpaceSessionAPITest(t *testing.T) (*Handlers, *spacerepo.Module, int64
 	return NewHandlers(controller.NewModule(repos, &baserepo.UserAuthRepository{DB: db})), repos, userID
 }
 
-func TestCreateSpaceBrowserSessionReturnsToken(t *testing.T) {
+func TestCreateSpaceBrowserSessionReturnsTokenWhenCacheEvictionFails(t *testing.T) {
 	handlers, repos, userID := setupSpaceSessionAPITest(t)
+	handlers.Module.UserTokens = failingUserTokenTerminator{}
+	authToken := "space-bootstrap-token"
+	require.NoError(t, (&baserepo.UserAuthRepository{DB: repos.Sessions.DB}).AddToken(userID, ente.Photos, authToken, "127.0.0.1", "space-test"))
 	router := gin.New()
 	router.POST("/account/space/sessions", handlers.CreateBrowserSession)
 	req := httptest.NewRequest(http.MethodPost, "/account/space/sessions", bytes.NewBufferString(`{"sessionWrapKey":"session-wrap-key"}`))
 	req.Header.Set("X-Auth-User-ID", strconv.FormatInt(userID, 10))
+	req.Header.Set("X-Auth-Token", authToken)
 	recorder := httptest.NewRecorder()
 
 	router.ServeHTTP(recorder, req)
@@ -66,7 +78,9 @@ func TestCreateSpaceBrowserSessionReturnsToken(t *testing.T) {
 }
 
 func TestRegisteredTokenSessionRoutesAllowSessionCreationBeforeBrowserSession(t *testing.T) {
-	handlers, _, userID := setupSpaceSessionAPITest(t)
+	handlers, repos, userID := setupSpaceSessionAPITest(t)
+	authToken := "space-route-bootstrap-token"
+	require.NoError(t, (&baserepo.UserAuthRepository{DB: repos.Sessions.DB}).AddToken(userID, ente.Photos, authToken, "127.0.0.1", "space-test"))
 	router := gin.New()
 	tokenPrivateAPI := router.Group("")
 	spacePrivateAPI := router.Group("")
@@ -80,6 +94,7 @@ func TestRegisteredTokenSessionRoutesAllowSessionCreationBeforeBrowserSession(t 
 		bytes.NewBufferString(`{"sessionWrapKey":"session-wrap-key"}`),
 	)
 	sessionReq.Header.Set("X-Auth-User-ID", strconv.FormatInt(userID, 10))
+	sessionReq.Header.Set("X-Auth-Token", authToken)
 	sessionRecorder := httptest.NewRecorder()
 
 	router.ServeHTTP(sessionRecorder, sessionReq)
@@ -149,11 +164,19 @@ func TestBootstrapBrowserSessionAcceptsHeader(t *testing.T) {
 	require.JSONEq(t, `{"sessionWrapKey":"session-wrap-key"}`, recorder.Body.String())
 }
 
-func TestDeleteBrowserSessionRevokesHeaderSession(t *testing.T) {
+func TestDeleteBrowserSessionRevokesAllUserSessions(t *testing.T) {
 	handlers, repos, userID := setupSpaceSessionAPITest(t)
+	otherUserID := testutil.InsertUser(t, repos.Sessions.DB, testutil.UserFixture{
+		Email:        "other-space-session@example.com",
+		CreationTime: timeutil.Microseconds(),
+	})
 	token := "valid-space-session-token"
 	tokenHash := sha256.Sum256([]byte(token))
 	require.NoError(t, repos.Sessions.CreateBrowserSession(context.Background(), tokenHash[:], userID, "session-wrap-key", timeutil.NDaysFromNow(1)))
+	secondHash := sha256.Sum256([]byte("second-space-session-token"))
+	require.NoError(t, repos.Sessions.CreateBrowserSession(context.Background(), secondHash[:], userID, "second-wrap-key", timeutil.NDaysFromNow(1)))
+	otherHash := sha256.Sum256([]byte("other-user-space-session-token"))
+	require.NoError(t, repos.Sessions.CreateBrowserSession(context.Background(), otherHash[:], otherUserID, "other-wrap-key", timeutil.NDaysFromNow(1)))
 	router := gin.New()
 	router.DELETE("/account/space/sessions/current", handlers.DeleteBrowserSession)
 	req := httptest.NewRequest(http.MethodDelete, "/account/space/sessions/current", nil)
@@ -163,6 +186,29 @@ func TestDeleteBrowserSessionRevokesHeaderSession(t *testing.T) {
 	router.ServeHTTP(recorder, req)
 
 	require.Equal(t, http.StatusOK, recorder.Code)
-	_, err := repos.Sessions.GetBrowserSession(context.Background(), tokenHash[:])
-	require.Error(t, err)
+	var count int
+	require.NoError(t, repos.Sessions.DB.QueryRow(`SELECT COUNT(*) FROM space_browser_sessions WHERE user_id = $1`, userID).Scan(&count))
+	require.Zero(t, count)
+	require.NoError(t, repos.Sessions.DB.QueryRow(`SELECT COUNT(*) FROM space_browser_sessions WHERE user_id = $1`, otherUserID).Scan(&count))
+	require.Equal(t, 1, count)
+}
+
+func TestDeleteBrowserSessionDoesNotAcceptExpiredSession(t *testing.T) {
+	handlers, repos, userID := setupSpaceSessionAPITest(t)
+	expiredToken := "expired-space-session-token"
+	expiredHash := sha256.Sum256([]byte(expiredToken))
+	require.NoError(t, repos.Sessions.CreateBrowserSession(context.Background(), expiredHash[:], userID, "expired-wrap-key", timeutil.Microseconds()-1))
+	activeHash := sha256.Sum256([]byte("active-space-session-token"))
+	require.NoError(t, repos.Sessions.CreateBrowserSession(context.Background(), activeHash[:], userID, "active-wrap-key", timeutil.NDaysFromNow(1)))
+	router := gin.New()
+	router.DELETE("/account/space/sessions/current", handlers.DeleteBrowserSession)
+	req := httptest.NewRequest(http.MethodDelete, "/account/space/sessions/current", nil)
+	req.Header.Set(controller.SpaceBrowserSessionTokenHeader, expiredToken)
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusUnauthorized, recorder.Code)
+	_, err := repos.Sessions.GetBrowserSession(context.Background(), activeHash[:])
+	require.NoError(t, err)
 }

--- a/server/space/controller/assets.go
+++ b/server/space/controller/assets.go
@@ -25,8 +25,8 @@ const (
 	maxPostUploadBytes     int64 = 5 * 1024 * 1024
 	maxAvatarUploadBytes   int64 = 2 * 1024 * 1024
 	maxCoverUploadBytes    int64 = 2 * 1024 * 1024
-	uploadURLExpiry              = 15 * time.Minute
-	uploadTempObjectExpiry       = 2 * uploadURLExpiry
+	uploadURLExpiry              = spacerepo.SpaceUploadURLExpiry
+	uploadTempObjectExpiry       = spacerepo.SpaceUploadCleanupDelay
 	uploadPurposePost            = spacerepo.TempObjectPurposePost
 	uploadPurposeAvatar          = spacerepo.TempObjectPurposeAvatar
 	uploadPurposeCover           = spacerepo.TempObjectPurposeCover

--- a/server/space/controller/posts.go
+++ b/server/space/controller/posts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/ente/museum/ente"
@@ -14,12 +15,19 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const spacePostLimitWarningThreshold = 200
+
+type SpaceAbuseNotifier interface {
+	NotifyPotentialAbuse(message string)
+}
+
 type PostsController struct {
 	PostsRepo     *repo.PostsRepository
 	SpacesRepo    *repo.SpacesRepository
 	FriendsRepo   *repo.FriendsRepository
 	AssetsRepo    *repo.AssetsRepository
 	EmailNotifier SpaceEmailNotifier
+	AbuseNotifier SpaceAbuseNotifier
 	auth          authDeps
 }
 
@@ -68,12 +76,21 @@ func (c *PostsController) Create(ctx context.Context, space *repo.SpaceRecord, r
 			MetadataCipher: metadataCipher,
 		})
 	}
-	postID, err := c.PostsRepo.CreatePost(ctx, space.SpaceID, encryptedPostKey, captionCipher, req.KeyVersion, assets)
+	postID, postCount, err := c.PostsRepo.CreatePost(ctx, space.SpaceID, encryptedPostKey, captionCipher, req.KeyVersion, assets)
 	if err != nil {
 		if errors.Is(stacktrace.RootCause(err), sql.ErrNoRows) {
 			return nil, ente.NewBadRequestWithMessage("keyVersion does not match current space version")
 		}
+		if errors.Is(stacktrace.RootCause(err), repo.ErrSpacePostLimitReached) {
+			return nil, ente.NewConflictError("space post limit reached")
+		}
 		return nil, err
+	}
+	if postCount == spacePostLimitWarningThreshold && c.AbuseNotifier != nil {
+		go c.AbuseNotifier.NotifyPotentialAbuse(fmt.Sprintf(
+			"Space %s owned by user %d has reached %d of %d posts",
+			space.SpaceID, space.OwnerID, postCount, repo.MaxPostsPerSpace,
+		))
 	}
 	c.notifyFriendsOfNewPost(space.SpaceID, space.SpaceSlug)
 	return &models.CreatePostResponse{PostID: postID}, nil

--- a/server/space/controller/sessions.go
+++ b/server/space/controller/sessions.go
@@ -26,7 +26,7 @@ type CreatedBrowserSession struct {
 	Response models.SpaceBrowserSessionResponse
 }
 
-func (c *SessionsController) CreateBrowserSession(ctx *gin.Context, userID int64, sessionWrapKey string) (*CreatedBrowserSession, error) {
+func (c *SessionsController) CreateBrowserSession(ctx *gin.Context, userID int64, authToken string, sessionWrapKey string) (*CreatedBrowserSession, error) {
 	sessionToken := auth.GenerateURLSafeRandomString(32)
 	sessionWrapKey = strings.TrimSpace(sessionWrapKey)
 	if sessionWrapKey == "" {
@@ -34,7 +34,7 @@ func (c *SessionsController) CreateBrowserSession(ctx *gin.Context, userID int64
 	}
 	sessionHash := sha256.Sum256([]byte(sessionToken))
 	expiresAt := timeutil.NDaysFromNow(spaceBrowserSessionDurationDays)
-	if err := c.SessionsRepo.CreateBrowserSession(ctx, sessionHash[:], userID, sessionWrapKey, expiresAt); err != nil {
+	if err := c.SessionsRepo.ExchangeBrowserSession(ctx, authToken, sessionHash[:], userID, sessionWrapKey, expiresAt); err != nil {
 		return nil, err
 	}
 	return &CreatedBrowserSession{
@@ -78,10 +78,7 @@ func validateBrowserSession(ctx *gin.Context, sessionsRepo *repo.SessionsReposit
 	return session, nil
 }
 
-func (c *SessionsController) RevokeBrowserSession(ctx *gin.Context, sessionToken string) error {
-	if sessionToken == "" {
-		return nil
-	}
+func (c *SessionsController) RevokeBrowserSessions(ctx *gin.Context, sessionToken string) error {
 	sessionHash := sha256.Sum256([]byte(sessionToken))
-	return c.SessionsRepo.DeleteBrowserSession(ctx, sessionHash[:])
+	return c.SessionsRepo.DeleteBrowserSessionsForToken(ctx, sessionHash[:])
 }

--- a/server/space/controller/test_helpers_test.go
+++ b/server/space/controller/test_helpers_test.go
@@ -56,7 +56,8 @@ func testCreatePost(ctx context.Context, module *spacerepo.Module, _ int64, spac
 	if captionCipher != nil {
 		caption = testSpaceBytes(*captionCipher)
 	}
-	return module.Posts.CreatePost(ctx, spaceID, testSpaceBytes(encryptedPostKey), caption, keyVersion, objects)
+	postID, _, err := module.Posts.CreatePost(ctx, spaceID, testSpaceBytes(encryptedPostKey), caption, keyVersion, objects)
+	return postID, err
 }
 
 func insertSpaceControllerUser(t *testing.T, module *spacerepo.Module, email string, publicKey string) int64 {

--- a/server/space/repo/module_test.go
+++ b/server/space/repo/module_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
+	"errors"
 	"sort"
 	"strconv"
 	"testing"
 
+	"github.com/ente/museum/ente"
 	"github.com/ente/museum/internal/testutil"
 	timeutil "github.com/ente/museum/pkg/utils/time"
 	"github.com/stretchr/testify/require"
@@ -251,6 +253,63 @@ func TestGetBrowserSession(t *testing.T) {
 	require.Equal(t, userID, session.UserID)
 	require.Equal(t, "session-wrap-key", session.SessionWrapKey)
 	require.Equal(t, expiresAt, session.ExpiresAt)
+}
+
+func TestExchangeBrowserSessionConsumesTokenOnce(t *testing.T) {
+	ctx := context.Background()
+	module := newSpaceTestModule(t)
+	userID := insertSpaceUser(t, module, "browser-session-exchange@example.com", "browser-session-exchange-public")
+	authToken := "browser-session-exchange-token"
+	_, err := module.Sessions.DB.Exec(`
+		INSERT INTO tokens (user_id, token, creation_time, app)
+		VALUES ($1, $2, $3, 'photos')
+	`, userID, authToken, timeutil.Microseconds())
+	require.NoError(t, err)
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	for _, tokenHash := range [][]byte{[]byte("first-space-token-hash"), []byte("second-space-token-hash")} {
+		go func(tokenHash []byte) {
+			<-start
+			errs <- module.Sessions.ExchangeBrowserSession(ctx, authToken, tokenHash, userID, "session-wrap-key", timeutil.NDaysFromNow(1))
+		}(tokenHash)
+	}
+	close(start)
+
+	var created, rejected int
+	for range 2 {
+		err := <-errs
+		if err == nil {
+			created++
+		} else if errors.Is(err, ente.ErrAuthenticationRequired) {
+			rejected++
+		} else {
+			require.NoError(t, err)
+		}
+	}
+	require.Equal(t, 1, created)
+	require.Equal(t, 1, rejected)
+	require.Equal(t, int64(1), countSpaceRows(t, module, `SELECT COUNT(*) FROM space_browser_sessions WHERE user_id = $1`, userID))
+}
+
+func TestExchangeBrowserSessionKeepsTokenWhenSessionCreationFails(t *testing.T) {
+	ctx := context.Background()
+	module := newSpaceTestModule(t)
+	userID := insertSpaceUser(t, module, "browser-session-rollback@example.com", "browser-session-rollback-public")
+	authToken := "browser-session-rollback-token"
+	tokenHash := []byte("duplicate-space-token-hash")
+	_, err := module.Sessions.DB.Exec(`
+		INSERT INTO tokens (user_id, token, creation_time, app)
+		VALUES ($1, $2, $3, 'photos')
+	`, userID, authToken, timeutil.Microseconds())
+	require.NoError(t, err)
+	require.NoError(t, module.Sessions.CreateBrowserSession(ctx, tokenHash, userID, "existing-wrap-key", timeutil.NDaysFromNow(1)))
+
+	err = module.Sessions.ExchangeBrowserSession(ctx, authToken, tokenHash, userID, "new-wrap-key", timeutil.NDaysFromNow(1))
+	require.Error(t, err)
+	var isDeleted bool
+	require.NoError(t, module.Sessions.DB.QueryRow(`SELECT is_deleted FROM tokens WHERE token = $1`, authToken).Scan(&isDeleted))
+	require.False(t, isDeleted)
 }
 
 func TestSpaceAccountDeletionResetAccountDeletionAccess(t *testing.T) {

--- a/server/space/repo/module_test.go
+++ b/server/space/repo/module_test.go
@@ -203,7 +203,43 @@ func testCreatePost(ctx context.Context, module *Module, _ int64, spaceID string
 	if captionCipher != nil {
 		caption = testSpaceBytes(*captionCipher)
 	}
-	return module.Posts.CreatePost(ctx, spaceID, testSpaceBytes(encryptedPostKey), caption, keyVersion, objects)
+	postID, _, err := module.Posts.CreatePost(ctx, spaceID, testSpaceBytes(encryptedPostKey), caption, keyVersion, objects)
+	return postID, err
+}
+
+func TestCreatePostEnforcesSpacePostLimit(t *testing.T) {
+	module := newSpaceTestModule(t)
+	ctx := context.Background()
+	userID := insertSpaceUser(t, module, "post-limit@example.com", "post-limit-public")
+	space, err := testCreateSpace(ctx, module, userID, "post_limit", "root", "public", "secret", "nonce", "profile")
+	require.NoError(t, err)
+
+	_, err = module.Posts.DB.ExecContext(ctx, `
+		INSERT INTO space_posts (space_id, encrypted_post_key, key_version)
+		SELECT $1, 'post-key', $2
+		FROM generate_series(1, $3)
+	`, space.SpaceID, space.CurrentVersion, MaxPostsPerSpace)
+	require.NoError(t, err)
+
+	_, postCount, err := module.Posts.CreatePost(ctx, space.SpaceID, testSpaceBytes("post-key"), nil, space.CurrentVersion, nil)
+	require.ErrorIs(t, err, ErrSpacePostLimitReached)
+	require.Equal(t, MaxPostsPerSpace, postCount)
+
+	_, err = module.Posts.DB.ExecContext(ctx, `
+		UPDATE space_posts
+		SET is_deleted = TRUE
+		WHERE post_id = (
+			SELECT MIN(post_id)
+			FROM space_posts
+			WHERE space_id = $1
+		)
+	`, space.SpaceID)
+	require.NoError(t, err)
+
+	postID, postCount, err := module.Posts.CreatePost(ctx, space.SpaceID, testSpaceBytes("post-key"), nil, space.CurrentVersion, nil)
+	require.NoError(t, err)
+	require.NotZero(t, postID)
+	require.Equal(t, MaxPostsPerSpace, postCount)
 }
 
 func testUpdateCaption(ctx context.Context, module *Module, postID int64, _ int64, spaceID string, captionCipher *string) error {

--- a/server/space/repo/posts.go
+++ b/server/space/repo/posts.go
@@ -3,12 +3,17 @@ package repo
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"strconv"
 	"strings"
 
 	"github.com/ente/museum/ente/base"
 	"github.com/ente/stacktrace"
 )
+
+const MaxPostsPerSpace = 250
+
+var ErrSpacePostLimitReached = errors.New("space post limit reached")
 
 func postRecordSelectSQL(viewerLikedExpr string) string {
 	return `
@@ -34,10 +39,10 @@ func scanPostRecords(rows *sql.Rows) ([]SpacePostRecord, error) {
 	return out, nil
 }
 
-func (r *PostsRepository) CreatePost(ctx context.Context, spaceID string, encryptedPostKey []byte, captionCipher []byte, keyVersion int, objects []SpacePostAssetRecord) (int64, error) {
+func (r *PostsRepository) CreatePost(ctx context.Context, spaceID string, encryptedPostKey []byte, captionCipher []byte, keyVersion int, objects []SpacePostAssetRecord) (int64, int, error) {
 	tx, err := r.DB.BeginTx(ctx, nil)
 	if err != nil {
-		return 0, stacktrace.Propagate(err, "")
+		return 0, 0, stacktrace.Propagate(err, "")
 	}
 	defer tx.Rollback()
 	var currentVersion int
@@ -47,10 +52,21 @@ func (r *PostsRepository) CreatePost(ctx context.Context, spaceID string, encryp
 		WHERE space_id = $1
 		FOR UPDATE
 	`, spaceID).Scan(&currentVersion); err != nil {
-		return 0, stacktrace.Propagate(err, "")
+		return 0, 0, stacktrace.Propagate(err, "")
 	}
 	if currentVersion != keyVersion {
-		return 0, sql.ErrNoRows
+		return 0, 0, sql.ErrNoRows
+	}
+	var postCount int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM space_posts
+		WHERE space_id = $1 AND is_deleted = FALSE
+	`, spaceID).Scan(&postCount); err != nil {
+		return 0, 0, stacktrace.Propagate(err, "")
+	}
+	if postCount >= MaxPostsPerSpace {
+		return 0, postCount, ErrSpacePostLimitReached
 	}
 	caption := []byte{}
 	if captionCipher != nil {
@@ -62,23 +78,23 @@ func (r *PostsRepository) CreatePost(ctx context.Context, spaceID string, encryp
 		VALUES ($1, $2, $3, $4)
 		RETURNING post_id
 	`, spaceID, encryptedPostKey, caption, keyVersion).Scan(&postID); err != nil {
-		return 0, stacktrace.Propagate(err, "")
+		return 0, 0, stacktrace.Propagate(err, "")
 	}
 	for _, obj := range objects {
 		if _, err := tx.ExecContext(ctx, `
 			INSERT INTO space_post_assets (post_id, object_key, bucket_id, size, position, metadata_cipher)
 			VALUES ($1, $2, $3, $4, $5, $6)
 		`, postID, obj.ObjectKey, obj.BucketID, obj.Size, obj.Position, obj.MetadataCipher); err != nil {
-			return 0, stacktrace.Propagate(err, "")
+			return 0, 0, stacktrace.Propagate(err, "")
 		}
 		if err := ConsumeTempObjectTx(ctx, tx, obj.ObjectKey, TempObjectPurposePost, &spaceID); err != nil {
-			return 0, stacktrace.Propagate(err, "failed to consume staged space post upload")
+			return 0, 0, stacktrace.Propagate(err, "failed to consume staged space post upload")
 		}
 	}
 	if err := tx.Commit(); err != nil {
-		return 0, stacktrace.Propagate(err, "")
+		return 0, 0, stacktrace.Propagate(err, "")
 	}
-	return postID, nil
+	return postID, postCount + 1, nil
 }
 
 func (r *PostsRepository) GetPost(ctx context.Context, postID int64, viewerSpaceID string) (*SpacePostRecord, error) {

--- a/server/space/repo/profile_assets.go
+++ b/server/space/repo/profile_assets.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	timeutil "github.com/ente/museum/pkg/utils/time"
 	"github.com/ente/stacktrace"
 )
 
@@ -110,6 +111,7 @@ func queueProfileAssetCleanupTx(ctx context.Context, tx *sql.Tx, asset profileAs
 		Purpose:      asset.AssetType,
 		BucketID:     asset.BucketID,
 		ExpectedSize: size,
+		CleanupAfter: timeutil.Microseconds() + SpaceUploadCleanupDelay.Microseconds(),
 	})
 }
 

--- a/server/space/repo/sessions.go
+++ b/server/space/repo/sessions.go
@@ -3,9 +3,38 @@ package repo
 import (
 	"context"
 
+	"github.com/ente/museum/ente"
 	timeutil "github.com/ente/museum/pkg/utils/time"
 	"github.com/ente/stacktrace"
 )
+
+func (r *SessionsRepository) ExchangeBrowserSession(ctx context.Context, authToken string, tokenHash []byte, userID int64, sessionWrapKey string, expiresAt int64) error {
+	result, err := r.DB.ExecContext(ctx, `
+		WITH consumed_token AS (
+			UPDATE tokens
+			SET is_deleted = TRUE
+			WHERE user_id = $1
+			  AND token = $2
+			  AND is_deleted = FALSE
+			  AND (last_used_at IS NULL OR last_used_at >= now_utc_micro_seconds() - (365::BIGINT * 24 * 60 * 60 * 1000 * 1000))
+			RETURNING user_id
+		)
+		INSERT INTO space_browser_sessions (token_hash, user_id, session_wrap_key, expires_at)
+		SELECT $3, user_id, $4, $5
+		FROM consumed_token
+	`, userID, authToken, tokenHash, sessionWrapKey, expiresAt)
+	if err != nil {
+		return stacktrace.Propagate(err, "")
+	}
+	created, err := result.RowsAffected()
+	if err != nil {
+		return stacktrace.Propagate(err, "")
+	}
+	if created == 0 {
+		return ente.ErrAuthenticationRequired
+	}
+	return nil
+}
 
 func (r *SessionsRepository) CreateBrowserSession(ctx context.Context, tokenHash []byte, userID int64, sessionWrapKey string, expiresAt int64) error {
 	_, err := r.DB.ExecContext(ctx, `
@@ -49,4 +78,35 @@ func (r *SessionsRepository) TouchBrowserSession(ctx context.Context, tokenHash 
 func (r *SessionsRepository) DeleteBrowserSession(ctx context.Context, tokenHash []byte) error {
 	_, err := r.DB.ExecContext(ctx, `DELETE FROM space_browser_sessions WHERE token_hash = $1`, tokenHash)
 	return stacktrace.Propagate(err, "")
+}
+
+func (r *SessionsRepository) DeleteBrowserSessionsForToken(ctx context.Context, tokenHash []byte) error {
+	result, err := r.DB.ExecContext(ctx, `
+		DELETE FROM space_browser_sessions
+		WHERE user_id = (
+			SELECT user_id
+			FROM space_browser_sessions
+			WHERE token_hash = $1 AND expires_at > now_utc_micro_seconds()
+		)
+	`, tokenHash)
+	if err != nil {
+		return stacktrace.Propagate(err, "")
+	}
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		return stacktrace.Propagate(err, "")
+	}
+	if deleted == 0 {
+		return ente.ErrAuthenticationRequired
+	}
+	return nil
+}
+
+func (r *SessionsRepository) DeleteBrowserSessionsForUser(ctx context.Context, userID int64) error {
+	_, err := r.DB.ExecContext(ctx, `DELETE FROM space_browser_sessions WHERE user_id = $1`, userID)
+	return stacktrace.Propagate(err, "")
+}
+
+func (m *Module) RevokeBrowserSessions(ctx context.Context, userID int64) error {
+	return m.Sessions.DeleteBrowserSessionsForUser(ctx, userID)
 }

--- a/server/space/repo/temp_objects.go
+++ b/server/space/repo/temp_objects.go
@@ -60,7 +60,8 @@ func (r *AssetsRepository) GetTempObject(ctx context.Context, objectKey, purpose
 
 func ConsumeTempObjectTx(ctx context.Context, tx *sql.Tx, objectKey, purpose string, spaceID *string) error {
 	args := []any{objectKey, purpose}
-	query := `DELETE FROM space_temp_objects WHERE object_key = $1 AND purpose = $2`
+	// Cleanup changes cleanup_after before deleting from S3, claiming the object.
+	query := `DELETE FROM space_temp_objects WHERE object_key = $1 AND purpose = $2 AND cleanup_after = expires_at`
 	if spaceID != nil {
 		args = append(args, *spaceID)
 		query += fmt.Sprintf(" AND space_id = $%d", len(args))

--- a/server/space/repo/temp_objects.go
+++ b/server/space/repo/temp_objects.go
@@ -4,8 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/ente/stacktrace"
+)
+
+const (
+	SpaceUploadURLExpiry    = 15 * time.Minute
+	SpaceUploadCleanupDelay = 2 * SpaceUploadURLExpiry
 )
 
 const (
@@ -33,7 +39,7 @@ func QueueObjectCleanupTx(ctx context.Context, tx *sql.Tx, rec SpaceTempObjectRe
 	}
 	_, err := tx.ExecContext(ctx, `
 		INSERT INTO space_temp_objects (object_key, space_id, purpose, bucket_id, expected_size, expires_at, cleanup_after)
-		VALUES ($1, $2, $3, $4, $5, now_utc_micro_seconds(), now_utc_micro_seconds())
+		VALUES ($1, $2, $3, $4, $5, now_utc_micro_seconds(), COALESCE(NULLIF($6::BIGINT, 0), now_utc_micro_seconds()))
 		ON CONFLICT (object_key) DO UPDATE
 		SET space_id = EXCLUDED.space_id,
 		    purpose = EXCLUDED.purpose,
@@ -41,7 +47,7 @@ func QueueObjectCleanupTx(ctx context.Context, tx *sql.Tx, rec SpaceTempObjectRe
 		    expected_size = EXCLUDED.expected_size,
 		    expires_at = EXCLUDED.expires_at,
 		    cleanup_after = EXCLUDED.cleanup_after
-	`, rec.ObjectKey, rec.SpaceID, rec.Purpose, rec.BucketID, expectedSize)
+	`, rec.ObjectKey, rec.SpaceID, rec.Purpose, rec.BucketID, expectedSize, rec.CleanupAfter)
 	return stacktrace.Propagate(err, "")
 }
 

--- a/web/apps/space/src/components/ConfirmationActionSheet.tsx
+++ b/web/apps/space/src/components/ConfirmationActionSheet.tsx
@@ -14,6 +14,7 @@ interface ConfirmationActionSheetProps {
     appearance?: "light" | "dark";
     open: boolean;
     title: string;
+    description?: string;
     confirmLabel: string;
     confirmBackgroundColor?: string;
     confirmActionPhase?: SpaceActionPhase | null;
@@ -32,6 +33,7 @@ export const ConfirmationActionSheet: React.FC<
     appearance = "light",
     open,
     title,
+    description,
     confirmLabel,
     confirmBackgroundColor = dangerColor,
     confirmActionPhase = null,
@@ -127,12 +129,27 @@ export const ConfirmationActionSheet: React.FC<
                 >
                     {title}
                 </Box>
+                {description && (
+                    <Box
+                        sx={{
+                            color: isDark ? "#BDBDBD" : "#666666",
+                            fontFamily: '"Inter Variable", Inter, sans-serif',
+                            fontSize: 13,
+                            lineHeight: "18px",
+                            mt: "8px",
+                            px: "20px",
+                            textAlign: "center",
+                        }}
+                    >
+                        {description}
+                    </Box>
+                )}
                 <Box
                     sx={{
                         display: "flex",
                         flexDirection: "column",
                         gap: "12px",
-                        mt: "28px",
+                        mt: description ? "20px" : "28px",
                     }}
                 >
                     <SheetButton

--- a/web/apps/space/src/pages/app/index.tsx
+++ b/web/apps/space/src/pages/app/index.tsx
@@ -5,6 +5,7 @@ import { HomeScreen, homeBackground } from "screens/HomeScreen";
 import {
     createCurrentPhotoPost,
     deleteCurrentPost,
+    isSpacePostLimitReachedError,
     loadCurrentFeedPage,
     loadCurrentSpaceFriends,
     loadCurrentSpacePostAssetURL,
@@ -277,6 +278,9 @@ const Page: React.FC = () => {
                                   failLocalFeedPost(
                                       setLocalFeedPosts,
                                       localPostId,
+                                      isSpacePostLimitReachedError(error)
+                                          ? "post-limit"
+                                          : undefined,
                                   );
                                   throw error;
                               }

--- a/web/apps/space/src/pages/app/profile.tsx
+++ b/web/apps/space/src/pages/app/profile.tsx
@@ -5,6 +5,7 @@ import { ProfileScreen, profileBackground } from "screens/ProfileScreen";
 import {
     createCurrentPhotoPost,
     deleteCurrentPost,
+    isSpacePostLimitReachedError,
     loadCurrentSpaceFriendsCount,
     loadCurrentSpacePostAssetURL,
     loadCurrentSpaceProfilePostsPage,
@@ -174,7 +175,13 @@ const Page: React.FC = () => {
                             post,
                         );
                     } catch (error) {
-                        failLocalFeedPost(setLocalFeedPosts, localPostId);
+                        failLocalFeedPost(
+                            setLocalFeedPosts,
+                            localPostId,
+                            isSpacePostLimitReachedError(error)
+                                ? "post-limit"
+                                : undefined,
+                        );
                         throw error;
                     }
                 }}

--- a/web/apps/space/src/pages/app/settings.tsx
+++ b/web/apps/space/src/pages/app/settings.tsx
@@ -35,11 +35,10 @@ const Page: React.FC = () => {
                 onOpenProfile={() =>
                     void router.push(spaceRoutes.settingsProfile)
                 }
-                onLogout={() => {
-                    void spaceLogout().then(() => {
-                        resetAfterLogout();
-                        void router.push(spaceRoutes.onboarding);
-                    });
+                onLogout={async () => {
+                    await spaceLogout();
+                    resetAfterLogout();
+                    await router.push(spaceRoutes.onboarding);
                 }}
             />
         </>

--- a/web/apps/space/src/screens/HomeScreen.tsx
+++ b/web/apps/space/src/screens/HomeScreen.tsx
@@ -171,7 +171,7 @@ interface DraftSpacePostImage {
     width?: number;
 }
 
-type FeedTimestampStatus = "failed" | "posted" | "posting";
+type FeedTimestampStatus = "failed" | "post-limit" | "posted" | "posting";
 
 interface FeedItemProps {
     aspectRatio: number;
@@ -1086,14 +1086,17 @@ const FeedItem: React.FC<FeedItemProps> = ({
                                 aria-label={
                                     timestampStatus == "posting"
                                         ? "Posting"
-                                        : timestampStatus == "failed"
-                                          ? "Failed"
-                                          : "Posted"
+                                        : timestampStatus == "post-limit"
+                                          ? "Post limit reached. Please contact support."
+                                          : timestampStatus == "failed"
+                                            ? "Failed"
+                                            : "Posted"
                                 }
                                 sx={{
                                     alignItems: "center",
                                     color:
-                                        timestampStatus == "failed"
+                                        timestampStatus == "failed" ||
+                                        timestampStatus == "post-limit"
                                             ? dangerColor
                                             : "rgba(255, 255, 255, 0.86)",
                                     display: "flex",
@@ -1107,6 +1110,11 @@ const FeedItem: React.FC<FeedItemProps> = ({
                             >
                                 {timestampStatus == "posted" ? (
                                     <Box component="span">Posted</Box>
+                                ) : timestampStatus == "post-limit" ? (
+                                    <Box component="span">
+                                        Post limit reached. Please contact
+                                        support.
+                                    </Box>
                                 ) : timestampStatus == "failed" ? (
                                     <Box component="span">Failed</Box>
                                 ) : (
@@ -1617,7 +1625,13 @@ export const HomeScreen: React.FC<HomeScreenProps> = ({
                 name={item.name}
                 onOpenProfile={onOpenProfile}
                 postId={0}
-                timestampStatus={item.status == "failed" ? "failed" : "posting"}
+                timestampStatus={
+                    item.status == "failed"
+                        ? item.reason == "post-limit"
+                            ? "post-limit"
+                            : "failed"
+                        : "posting"
+                }
                 timestampMs={item.timestampMs}
                 viewerLiked={false}
             />

--- a/web/apps/space/src/screens/SettingsScreen.tsx
+++ b/web/apps/space/src/screens/SettingsScreen.tsx
@@ -11,6 +11,7 @@ import {
 import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
 import { Box } from "@mui/material";
 import { ConfirmationActionSheet } from "components/ConfirmationActionSheet";
+import type { SpaceActionPhase } from "components/SpaceActionFeedback";
 import { SpaceButtonSpinner } from "components/SpaceButtonSpinner";
 import React from "react";
 import { spaceTouchTargetSize } from "styles/touchTargets";
@@ -58,7 +59,7 @@ const spaceLinks = [
 ] as const;
 
 interface SettingsScreenProps {
-    onLogout: () => void;
+    onLogout: () => Promise<void>;
     onBack?: () => void;
     onOpenProfile: () => void;
 }
@@ -221,10 +222,26 @@ export const SettingsScreen: React.FC<SettingsScreenProps> = ({
     onOpenProfile,
 }) => {
     const [logoutSheetOpen, setLogoutSheetOpen] = React.useState(false);
+    const [logoutActionPhase, setLogoutActionPhase] =
+        React.useState<SpaceActionPhase | null>(null);
+    const [logoutErrorMessage, setLogoutErrorMessage] = React.useState<
+        string | null
+    >(null);
+    const isLogoutRunning = logoutActionPhase != null;
 
     const handleConfirmLogout = () => {
+        setLogoutErrorMessage(null);
+        setLogoutActionPhase("busy");
+        void onLogout().catch((error: unknown) => {
+            console.error("Failed to log out Space sessions", error);
+            setLogoutActionPhase(null);
+            setLogoutErrorMessage("Couldn't log out. Please try again.");
+        });
+    };
+
+    const cancelLogout = () => {
         setLogoutSheetOpen(false);
-        onLogout();
+        setLogoutErrorMessage(null);
     };
 
     return (
@@ -360,9 +377,14 @@ export const SettingsScreen: React.FC<SettingsScreenProps> = ({
             </Box>
             <ConfirmationActionSheet
                 open={logoutSheetOpen}
-                title="Are you sure you want to logout?"
+                title="Log out of Space?"
+                description="This will also log you out of Space on any other devices."
                 confirmLabel="Yes, logout"
-                onCancel={() => setLogoutSheetOpen(false)}
+                confirmActionPhase={logoutActionPhase}
+                confirmDisabled={isLogoutRunning}
+                errorMessage={logoutErrorMessage}
+                cancelDisabled={isLogoutRunning}
+                onCancel={cancelLogout}
                 onConfirm={handleConfirmLogout}
             />
         </Box>

--- a/web/apps/space/src/services/space.ts
+++ b/web/apps/space/src/services/space.ts
@@ -1088,6 +1088,13 @@ export const createCurrentPhotoPost = async ({
     }
 };
 
+export const isSpacePostLimitReachedError = (error: unknown) => {
+    if (!error || typeof error != "object" || !("status" in error)) {
+        return false;
+    }
+    return (error as { status?: unknown }).status == 409;
+};
+
 const normalizedImageDimension = (dimension: number | undefined) =>
     typeof dimension == "number" && Number.isFinite(dimension) && dimension > 0
         ? Math.round(dimension)

--- a/web/apps/space/src/services/spaceLogout.ts
+++ b/web/apps/space/src/services/spaceLogout.ts
@@ -1,7 +1,6 @@
 import { accountLogout } from "ente-accounts-rs/services/logout";
-import { revokeSpaceBrowserSession } from "services/spacePersistentSession";
+import { revokeSpaceBrowserSessions } from "services/spacePersistentSession";
 
 export const spaceLogout = async () => {
-    await revokeSpaceBrowserSession();
-    await accountLogout();
+    if (await revokeSpaceBrowserSessions()) await accountLogout();
 };

--- a/web/apps/space/src/services/spacePersistentSession.ts
+++ b/web/apps/space/src/services/spacePersistentSession.ts
@@ -9,6 +9,7 @@ import {
     generateKey,
     toB64,
 } from "ente-accounts-rs/services/crypto";
+import { accountLogout } from "ente-accounts-rs/services/logout";
 import { ensureOk, publicRequestHeaders } from "ente-base/http";
 import { apiURL } from "ente-base/origins";
 import { removeAuthToken } from "ente-base/token";
@@ -121,6 +122,11 @@ export const clearSpaceBrowserSession = () => {
     clearSpaceSecureSessionStorage();
 };
 
+export const logoutRevokedSpaceSession = async () => {
+    clearSpaceBrowserSession();
+    await accountLogout();
+};
+
 export const savedSpaceSessionToken = () =>
     savedPersistedSession()?.sessionToken;
 
@@ -197,7 +203,8 @@ const restoreSpaceBrowserSession = async () => {
         },
     });
     if (res.status == 401) {
-        clearSpaceBrowserSession();
+        await logoutRevokedSpaceSession();
+        window.location.replace("/");
         return false;
     }
     ensureOk(res);
@@ -246,10 +253,9 @@ export const getOrCreateSpaceRootKey = async (
     );
 };
 
-export const revokeSpaceBrowserSession = async () => {
+export const revokeSpaceBrowserSessions = async () => {
     const sessionToken = savedSpaceSessionToken();
-    try {
-        if (!sessionToken) return;
+    if (sessionToken) {
         const res = await fetch(
             await apiURL("/account/space/sessions/current"),
             {
@@ -260,10 +266,12 @@ export const revokeSpaceBrowserSession = async () => {
                 },
             },
         );
-        if (res.status != 401) ensureOk(res);
-    } catch {
-        // Local logout must still complete if remote session revocation fails.
-    } finally {
-        clearSpaceBrowserSession();
+        if (res.status == 401) {
+            await logoutRevokedSpaceSession();
+            return false;
+        }
+        ensureOk(res);
     }
+    clearSpaceBrowserSession();
+    return true;
 };

--- a/web/apps/space/src/services/spaceProfile.ts
+++ b/web/apps/space/src/services/spaceProfile.ts
@@ -101,6 +101,9 @@ const spaceHTTPStatus = (error: unknown) => {
     return typeof status == "number" ? status : undefined;
 };
 
+export const isSpaceSessionUnauthorized = (error: unknown) =>
+    spaceHTTPStatus(error) == 401;
+
 const defaultOwnedSpace = (spaces: OwnedSpace[]) => spaces[0];
 
 const currentSpaceContextConfig = async () => {

--- a/web/apps/space/src/state/SpaceAppStateProvider.tsx
+++ b/web/apps/space/src/state/SpaceAppStateProvider.tsx
@@ -12,8 +12,10 @@ import {
     clearSpaceMediaURLCache,
 } from "services/space";
 import type { PendingSpacePasskeyVerification } from "services/spacePasskeyVerification";
+import { logoutRevokedSpaceSession } from "services/spacePersistentSession";
 import {
     clearCurrentSpaceContext,
+    isSpaceSessionUnauthorized,
     loadExistingSpaceAvatar,
     loadExistingSpaceCover,
     loadExistingSpaceProfile,
@@ -183,6 +185,11 @@ export const SpaceAppStateProvider: React.FC<React.PropsWithChildren> = ({
                 }
                 return nextProfile;
             } catch (error) {
+                if (isSpaceSessionUnauthorized(error)) {
+                    await logoutRevokedSpaceSession();
+                    window.location.replace("/");
+                    return null;
+                }
                 console.error("Failed to load space profile", error);
                 if (profileLoadGenerationRef.current == generation) {
                     setProfileLoadError(profileErrorMessage(error));

--- a/web/apps/space/src/state/spaceAppState.tsx
+++ b/web/apps/space/src/state/spaceAppState.tsx
@@ -27,6 +27,7 @@ export interface PendingSpaceFeedPost {
 }
 
 export type FailedSpaceFeedPost = Omit<PendingSpaceFeedPost, "status"> & {
+    reason?: "post-limit";
     status: "failed";
 };
 

--- a/web/apps/space/src/utils/localFeedPost.ts
+++ b/web/apps/space/src/utils/localFeedPost.ts
@@ -1,6 +1,9 @@
 import type React from "react";
 import type { SpacePost } from "services/space";
-import type { LocalSpaceFeedPost } from "state/spaceAppState";
+import type {
+    FailedSpaceFeedPost,
+    LocalSpaceFeedPost,
+} from "state/spaceAppState";
 
 let nextLocalFeedPostID = 0;
 
@@ -40,11 +43,12 @@ export const failLocalFeedPost = (
         React.SetStateAction<LocalSpaceFeedPost[]>
     >,
     localPostId: string,
+    reason?: FailedSpaceFeedPost["reason"],
 ) => {
     setLocalFeedPosts((currentPosts) =>
         currentPosts.map((item) =>
             item.id == localPostId && item.status == "pending"
-                ? { ...item, status: "failed" }
+                ? { ...item, reason, status: "failed" }
                 : item,
         ),
     );


### PR DESCRIPTION
- Atomically exchange bootstrap tokens and revoke all Space browser sessions on logout, credential changes, or account deletion.
- Cap each Space at 250 active posts, send an abuse warning at 200, and surface the limit in the web app.
- Prevent cleanup jobs from racing active uploads or profile asset replacements.