### PR TITLE
[space] Harden Space conversation APIs

### DIFF
--- a/server/space/api/register.go
+++ b/server/space/api/register.go
@@ -37,7 +37,6 @@ func Register(privateAPI, publicAPI gin.IRouter, handlers *Handlers) {
 	spaceAPI.GET("/friends/relationship", selected(handlers.FriendRelationship))
 	spaceAPI.POST("/friends/shares/refresh", selected(handlers.RefreshFriendShares))
 	spaceAPI.GET("/friends/shares", selected(handlers.ListFriendShares))
-	spaceAPI.POST("/rotate", selected(handlers.RotateSpaceKey))
 
 	publicAPI.GET("/spaces/:spaceID/profile", handlers.GetSpaceProfile)
 	publicAPI.GET("/spaces/:spaceID/assets/redirect", handlers.AssetRedirect)

--- a/server/space/controller/friends.go
+++ b/server/space/controller/friends.go
@@ -56,6 +56,9 @@ func (c *FriendsController) Add(ctx context.Context, requesterSpace *repo.SpaceR
 		if errors.Is(stacktrace.RootCause(err), sql.ErrNoRows) {
 			return nil, ente.NewBadRequestWithMessage("space key version is stale")
 		}
+		if errors.Is(stacktrace.RootCause(err), repo.ErrSpaceFriendRequestLimitReached) {
+			return nil, ente.NewConflictError("space friend request limit reached")
+		}
 		return nil, err
 	}
 	if becameFriends {

--- a/server/space/controller/messages.go
+++ b/server/space/controller/messages.go
@@ -63,6 +63,9 @@ func (c *MessagesController) Create(ctx context.Context, senderSpace *repo.Space
 		ReplyMessageID:               replyMessageID,
 	})
 	if err != nil {
+		if errors.Is(stacktrace.RootCause(err), repo.ErrSpaceMessageLimitReached) {
+			return nil, ente.NewConflictError("space message limit reached")
+		}
 		return nil, err
 	}
 	return toMessageResponse(*message), nil
@@ -109,6 +112,9 @@ func (c *MessagesController) ReplyToPost(ctx context.Context, senderSpace *repo.
 		ReplyPostID:                  sql.NullInt64{Int64: postID, Valid: true},
 	})
 	if err != nil {
+		if errors.Is(stacktrace.RootCause(err), repo.ErrSpaceMessageLimitReached) {
+			return nil, ente.NewConflictError("space message limit reached")
+		}
 		return nil, err
 	}
 	if c.EmailNotifier != nil {
@@ -348,7 +354,7 @@ func toMessageResponse(message repo.SpaceMessageRecord) *models.MessageResponse 
 	return resp
 }
 
-func toMessageConversationActivityResponse(activity repo.SpaceMessageConversationActivityRecord) models.MessageConversationActivityResponse {
+func toMessageConversationActivityMetadataResponse(activity repo.SpaceMessageConversationActivityRecord) models.MessageConversationActivityResponse {
 	resp := models.MessageConversationActivityResponse{
 		ID:        activity.ID,
 		Type:      activity.Type,
@@ -359,6 +365,18 @@ func toMessageConversationActivityResponse(activity repo.SpaceMessageConversatio
 		messageID := activity.MessageID.String
 		resp.MessageID = &messageID
 	}
+	if activity.PostID.Valid {
+		postID := activity.PostID.Int64
+		resp.PostID = &postID
+		if activity.PostSpaceID.Valid {
+			resp.PostSpaceID = activity.PostSpaceID.String
+		}
+	}
+	return resp
+}
+
+func toMessageConversationActivityResponse(activity repo.SpaceMessageConversationActivityRecord) models.MessageConversationActivityResponse {
+	resp := toMessageConversationActivityMetadataResponse(activity)
 	if activity.Kind.Valid {
 		resp.Kind = activity.Kind.String
 	}
@@ -378,23 +396,9 @@ func toMessageConversationActivityResponse(activity repo.SpaceMessageConversatio
 		replyMessageID := activity.ReplyMessageID.String
 		resp.ReplyMessageID = &replyMessageID
 	}
-	if activity.PostID.Valid {
-		postID := activity.PostID.Int64
-		resp.PostID = &postID
-		if activity.PostSpaceID.Valid {
-			resp.PostSpaceID = activity.PostSpaceID.String
-		}
-	}
 	return resp
 }
 
 func toUnreadMessageConversationActivityResponse(activity repo.SpaceMessageConversationActivityRecord) models.MessageConversationActivityResponse {
-	resp := toMessageConversationActivityResponse(activity)
-	resp.Kind = ""
-	resp.SenderSpaceID = ""
-	resp.RecipientSpaceID = ""
-	resp.MessageCipher = ""
-	resp.EncryptedMessageKey = ""
-	resp.ReplyMessageID = nil
-	return resp
+	return toMessageConversationActivityMetadataResponse(activity)
 }

--- a/server/space/controller/messages.go
+++ b/server/space/controller/messages.go
@@ -22,7 +22,8 @@ const (
 	maxSpaceMessageCipherDecodedBytes = 6 * 1024
 	maxSpaceMessageKeyEncodedBytes    = 1024
 	maxSpaceMessageKeyDecodedBytes    = 768
-	maxSpaceMessageIDBytes            = 128
+	spaceMessageIDPrefix              = "wmsg_"
+	spaceMessageIDSuffixLength        = 22
 )
 
 type MessagesController struct {
@@ -300,9 +301,17 @@ func sameMessageThread(message *repo.SpaceMessageRecord, firstSpaceID, secondSpa
 }
 
 func normalizeOptionalMessageID(messageID string) (string, error) {
-	messageID = strings.TrimSpace(messageID)
-	if len(messageID) > maxSpaceMessageIDBytes {
-		return "", ente.NewBadRequestWithMessage("messageId is too large")
+	if messageID == "" {
+		return "", nil
+	}
+	if len(messageID) != len(spaceMessageIDPrefix)+spaceMessageIDSuffixLength || !strings.HasPrefix(messageID, spaceMessageIDPrefix) {
+		return "", ente.NewBadRequestWithMessage("messageId is invalid")
+	}
+	for i := len(spaceMessageIDPrefix); i < len(messageID); i++ {
+		c := messageID[i]
+		if !((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+			return "", ente.NewBadRequestWithMessage("messageId is invalid")
+		}
 	}
 	return messageID, nil
 }

--- a/server/space/controller/messages_test.go
+++ b/server/space/controller/messages_test.go
@@ -145,10 +145,22 @@ func TestValidateCreateMessageRequestLimits(t *testing.T) {
 	_, _, _, err = decodeCreateMessageRequest(tooLargeKey)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "senderEncryptedMessageKey is too large")
+}
 
-	_, err = normalizeOptionalMessageID(strings.Repeat("m", maxSpaceMessageIDBytes+1))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "messageId is too large")
+func TestNormalizeOptionalMessageID(t *testing.T) {
+	messageID := "wmsg_0123456789ABCDEFGHIJKL"
+	normalizedMessageID, err := normalizeOptionalMessageID(messageID)
+	require.NoError(t, err)
+	require.Equal(t, messageID, normalizedMessageID)
+
+	for _, invalidMessageID := range []string{
+		"../../../spaces/space_0123456789ABCDEFGHIJKL/posts/42",
+		"wmsg_/../../posts/123456789",
+	} {
+		_, err = normalizeOptionalMessageID(invalidMessageID)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "messageId is invalid")
+	}
 }
 
 func createMessageControllerUserAndSpace(t *testing.T, repos *spacerepo.Module, slug string, publicKey string) (int64, *spacerepo.SpaceRecord) {

--- a/server/space/repo/friends.go
+++ b/server/space/repo/friends.go
@@ -12,9 +12,12 @@ import (
 )
 
 var (
-	ErrAlreadyFriends = errors.New("space users are already friends")
-	ErrSelfFriendship = errors.New("space users cannot friend themselves")
+	ErrAlreadyFriends                 = errors.New("space users are already friends")
+	ErrSelfFriendship                 = errors.New("space users cannot friend themselves")
+	ErrSpaceFriendRequestLimitReached = errors.New("space friend request limit reached")
 )
+
+const MaxPendingFriendRequestsPerSpace = 100
 
 type friendShareMutation struct {
 	SpaceID              string
@@ -203,6 +206,18 @@ func (r *FriendsRepository) CreateFriendRequest(ctx context.Context, requesterID
 		return &reverse, false, true, stacktrace.Propagate(tx.Commit(), "")
 	case !errors.Is(err, sql.ErrNoRows):
 		return nil, false, false, stacktrace.Propagate(err, "")
+	}
+
+	var pendingRequestCount int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM space_friend_requests
+		WHERE target_space_id = $1
+	`, targetSpaceID).Scan(&pendingRequestCount); err != nil {
+		return nil, false, false, stacktrace.Propagate(err, "")
+	}
+	if pendingRequestCount >= MaxPendingFriendRequestsPerSpace {
+		return nil, false, false, ErrSpaceFriendRequestLimitReached
 	}
 
 	if err := tx.QueryRowContext(ctx, `

--- a/server/space/repo/messages.go
+++ b/server/space/repo/messages.go
@@ -3,6 +3,7 @@ package repo
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -11,6 +12,10 @@ import (
 	"github.com/ente/stacktrace"
 	"github.com/lib/pq"
 )
+
+const MaxActiveMessagesSentPerSpace = 5000
+
+var ErrSpaceMessageLimitReached = errors.New("space message limit reached")
 
 const spaceMessageBaseSelectColumns = `
 	m.message_id,
@@ -174,9 +179,36 @@ func (r *MessagesRepository) CreateMessage(ctx context.Context, input CreateSpac
 	if input.ReplyMessageID.Valid {
 		replyMessageID = input.ReplyMessageID.String
 	}
+	tx, err := r.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
+	defer tx.Rollback()
+	var senderSpaceID string
+	if err := tx.QueryRowContext(ctx, `
+		SELECT space_id
+		FROM spaces
+		WHERE space_id = $1
+		FOR UPDATE
+	`, input.SenderSpaceID).Scan(&senderSpaceID); err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
+	var activeMessageCount int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM space_messages
+		WHERE sender_space_id = $1
+		  AND kind IN ('regular', 'post_reply')
+		  AND is_deleted = FALSE
+	`, senderSpaceID).Scan(&activeMessageCount); err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
+	if activeMessageCount >= MaxActiveMessagesSentPerSpace {
+		return nil, ErrSpaceMessageLimitReached
+	}
 	var createdAt int64
 	var updatedAt int64
-	if err := r.DB.QueryRowContext(ctx, `
+	if err := tx.QueryRowContext(ctx, `
 		INSERT INTO space_messages (
 			message_id,
 			sender_space_id,
@@ -192,6 +224,9 @@ func (r *MessagesRepository) CreateMessage(ctx context.Context, input CreateSpac
 		RETURNING created_at, updated_at
 	`, messageID, input.SenderSpaceID, input.RecipientSpaceID, input.Kind, input.MessageCipher, input.SenderEncryptedMessageKey, input.RecipientEncryptedMessageKey, replyPostID, replyMessageID).Scan(&createdAt, &updatedAt); err != nil {
 		return nil, wrapUnique(err, "message already exists")
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, stacktrace.Propagate(err, "")
 	}
 	return &SpaceMessageRecord{
 		MessageID:           messageID,
@@ -334,6 +369,12 @@ func (r *MessagesRepository) ListLatestChatSummaries(ctx context.Context, viewer
 			summary.LatestActivity = activity
 		}
 		if notificationCreatedAt.Valid && notificationCreatedAt.Int64 > readMarkers[friendSpaceID] {
+			activity.Kind = sql.NullString{}
+			activity.SenderSpaceID = sql.NullString{}
+			activity.RecipientSpaceID = sql.NullString{}
+			activity.MessageCipher = nil
+			activity.EncryptedMessageKey = nil
+			activity.ReplyMessageID = sql.NullString{}
 			summary.UnreadActivities = append(summary.UnreadActivities, activity)
 		}
 		out[friendSpaceID] = summary

--- a/server/space/repo/module_test.go
+++ b/server/space/repo/module_test.go
@@ -242,6 +242,87 @@ func TestCreatePostEnforcesSpacePostLimit(t *testing.T) {
 	require.Equal(t, MaxPostsPerSpace, postCount)
 }
 
+func TestCreateMessageEnforcesSenderLimit(t *testing.T) {
+	module := newSpaceTestModule(t)
+	ctx := context.Background()
+	aliceID := insertSpaceUser(t, module, "message-limit-alice@example.com", "message-limit-alice-public")
+	bobID := insertSpaceUser(t, module, "message-limit-bob@example.com", "message-limit-bob-public")
+	aliceSpace, err := testCreateSpace(ctx, module, aliceID, "message_limit_alice", "root", "public", "secret", "nonce", "profile")
+	require.NoError(t, err)
+	bobSpace, err := testCreateSpace(ctx, module, bobID, "message_limit_bob", "root", "public", "secret", "nonce", "profile")
+	require.NoError(t, err)
+
+	_, err = module.Messages.DB.ExecContext(ctx, `
+		INSERT INTO space_messages (
+			message_id,
+			sender_space_id,
+			recipient_space_id,
+			kind,
+			message_cipher,
+			sender_encrypted_message_key,
+			recipient_encrypted_message_key
+		)
+		SELECT 'message-limit-' || value, $1, $2, 'regular', $3, $4, $5
+		FROM generate_series(1, $6) AS value
+	`, aliceSpace.SpaceID, bobSpace.SpaceID, testSpaceBytes("cipher"), testSpaceBytes("sender-key"), testSpaceBytes("recipient-key"), MaxActiveMessagesSentPerSpace)
+	require.NoError(t, err)
+
+	input := CreateSpaceMessageRecord{
+		Kind:                         "regular",
+		SenderSpaceID:                aliceSpace.SpaceID,
+		RecipientSpaceID:             bobSpace.SpaceID,
+		MessageCipher:                testSpaceBytes("cipher"),
+		SenderEncryptedMessageKey:    testSpaceBytes("sender-key"),
+		RecipientEncryptedMessageKey: testSpaceBytes("recipient-key"),
+	}
+	_, err = module.Messages.CreateMessage(ctx, input)
+	require.ErrorIs(t, err, ErrSpaceMessageLimitReached)
+
+	input.SenderSpaceID = bobSpace.SpaceID
+	input.RecipientSpaceID = aliceSpace.SpaceID
+	_, err = module.Messages.CreateMessage(ctx, input)
+	require.NoError(t, err)
+
+	require.NoError(t, module.Messages.DeleteMessage(ctx, "message-limit-1", aliceSpace.SpaceID))
+	input.SenderSpaceID = aliceSpace.SpaceID
+	input.RecipientSpaceID = bobSpace.SpaceID
+	_, err = module.Messages.CreateMessage(ctx, input)
+	require.NoError(t, err)
+}
+
+func TestCreateFriendRequestEnforcesTargetLimit(t *testing.T) {
+	module := newSpaceTestModule(t)
+	ctx := context.Background()
+	targetID := insertSpaceUser(t, module, "request-limit-target@example.com", "request-limit-target-public")
+	targetSpace, err := testCreateSpace(ctx, module, targetID, "request_limit_target", "root", "public", "secret", "nonce", "profile")
+	require.NoError(t, err)
+
+	var firstRequestID int64
+	for i := 0; i < MaxPendingFriendRequestsPerSpace; i++ {
+		suffix := strconv.Itoa(i)
+		requesterID := insertSpaceUser(t, module, "request-limit-"+suffix+"@example.com", "request-limit-public-"+suffix)
+		requesterSpace, err := testCreateSpace(ctx, module, requesterID, "request_limit_"+suffix, "root", "public", "secret", "nonce", "profile")
+		require.NoError(t, err)
+		request, created, err := testCreateFriendRequest(ctx, module, requesterID, requesterSpace.SpaceID, targetSpace.SpaceID, "share-key", requesterSpace.CurrentVersion)
+		require.NoError(t, err)
+		require.True(t, created)
+		if i == 0 {
+			firstRequestID = request.RequestID
+		}
+	}
+
+	extraID := insertSpaceUser(t, module, "request-limit-extra@example.com", "request-limit-extra-public")
+	extraSpace, err := testCreateSpace(ctx, module, extraID, "request_limit_extra", "root", "public", "secret", "nonce", "profile")
+	require.NoError(t, err)
+	_, _, err = testCreateFriendRequest(ctx, module, extraID, extraSpace.SpaceID, targetSpace.SpaceID, "share-key", extraSpace.CurrentVersion)
+	require.ErrorIs(t, err, ErrSpaceFriendRequestLimitReached)
+
+	require.NoError(t, module.Friends.DeleteFriendRequest(ctx, targetSpace.SpaceID, firstRequestID))
+	_, created, err := testCreateFriendRequest(ctx, module, extraID, extraSpace.SpaceID, targetSpace.SpaceID, "share-key", extraSpace.CurrentVersion)
+	require.NoError(t, err)
+	require.True(t, created)
+}
+
 func testUpdateCaption(ctx context.Context, module *Module, postID int64, _ int64, spaceID string, captionCipher *string) error {
 	var caption []byte
 	if captionCipher != nil {
@@ -844,6 +925,10 @@ func TestLatestChatSummariesUseCurrentFriendActivities(t *testing.T) {
 	require.True(t, bobSummary.LatestActivity.PostID.Valid)
 	require.Equal(t, postID, bobSummary.LatestActivity.PostID.Int64)
 	require.Len(t, bobSummary.UnreadActivities, 2)
+	for _, activity := range bobSummary.UnreadActivities {
+		require.Empty(t, activity.MessageCipher)
+		require.Empty(t, activity.EncryptedMessageKey)
+	}
 	require.Equal(t, int64(1), countChatUnreadActivities(bobSummary.UnreadActivities))
 
 	require.NoError(t, module.Read.UpsertNotificationReadMarker(ctx, aliceSpace.SpaceID, bobSpace.SpaceID, 3000))


### PR DESCRIPTION
- Cap active sent messages and pending incoming friend requests.
- Validate Space message IDs against the expected format.
- Exclude encrypted message payloads from unread activity summaries.
- Disable the Space key rotation endpoint.
- Add coverage for message, friend request, and ID limits.