### PR TITLE
[space] Harden Space keys and service limits

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2524,6 +2524,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "urlencoding",
+ "zeroize",
 ]
 
 [[package]]

--- a/rust/e2e/tests/support/space.rs
+++ b/rust/e2e/tests/support/space.rs
@@ -25,7 +25,7 @@ pub async fn open_ctx(endpoint: &str, account: &TestAccount) -> AccountSpaceCtx 
         .post(format!("{endpoint}/account/space/sessions"))
         .header("X-Auth-Token", &account.auth_token)
         .header("X-Client-Package", App::Photos.client_package())
-        .json(&serde_json::json!({ "sessionWrapKey": "space-e2e-session-wrap-key" }))
+        .json(&serde_json::json!({ "sessionWrapKey": encode_b64(Key::generate().as_bytes()) }))
         .send()
         .await
         .expect("space session create request failed");

--- a/rust/space/Cargo.toml
+++ b/rust/space/Cargo.toml
@@ -10,6 +10,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 urlencoding = "2"
+zeroize = { version = "1.8", features = ["derive"] }
 
 [dev-dependencies]
 mockito = "1.6"

--- a/rust/space/src/client/mod.rs
+++ b/rust/space/src/client/mod.rs
@@ -34,7 +34,7 @@ use crate::transport::{
     SpaceKeyVersionResponse, SpaceLookupResponse, SpaceProfileResponse, UpdateSpaceSlugRequest,
 };
 use ente_core::{
-    crypto::{decode_b64, encode_b64},
+    crypto::{SecretVec, decode_b64, encode_b64},
     http::{Api, ApiConfig, Auth, Http},
 };
 const UPLOAD_PURPOSE_AVATAR: &str = "avatar";
@@ -74,28 +74,35 @@ fn profile_object_id_from_key(object_key: &str) -> Result<String> {
         .ok_or_else(|| SpaceError::InvalidInput("invalid profile asset object key".into()))
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct ResolvedSpaceAccess {
     space_key: Vec<u8>,
     key_version: i32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct ResolvedOwnedSpaceAccess {
     space_key: Vec<u8>,
     key_version: i32,
 }
 
-#[derive(Debug, Clone)]
 pub(crate) struct SpaceIdentity {
     public_key: Vec<u8>,
-    secret_key: Vec<u8>,
+    secret_key: SecretVec,
+}
+
+impl Clone for SpaceIdentity {
+    fn clone(&self) -> Self {
+        Self {
+            public_key: self.public_key.clone(),
+            secret_key: SecretVec::new(self.secret_key.to_vec()),
+        }
+    }
 }
 
 pub struct AccountSpaceCtx {
     api: Api,
-    space_root_key: Vec<u8>,
-    space_root_key_cache: Mutex<Option<Option<Vec<u8>>>>,
+    space_root_key: SecretVec,
     space_identity_cache: Mutex<BTreeMap<String, SpaceIdentity>>,
     owned_spaces_cache: Mutex<Option<Vec<SpaceKeyResponse>>>,
     friend_shares_cache: Mutex<BTreeMap<String, Vec<DecryptedFriendShare>>>,
@@ -103,6 +110,7 @@ pub struct AccountSpaceCtx {
 
 impl AccountSpaceCtx {
     pub fn open(input: OpenAccountSpaceCtxInput) -> Result<Self> {
+        let space_root_key = SecretVec::new(input.space_root_key);
         let api = build_api(
             &input.base_url,
             input.space_session_token,
@@ -112,8 +120,7 @@ impl AccountSpaceCtx {
         )?;
         Ok(Self {
             api,
-            space_root_key: input.space_root_key,
-            space_root_key_cache: Mutex::new(None),
+            space_root_key,
             space_identity_cache: Mutex::new(BTreeMap::new()),
             owned_spaces_cache: Mutex::new(None),
             friend_shares_cache: Mutex::new(BTreeMap::new()),
@@ -129,14 +136,11 @@ impl AccountSpaceCtx {
     }
 
     pub async fn get_space_root_key(&self) -> Result<Option<Vec<u8>>> {
-        Ok(Some(self.space_root_key.clone()))
+        Ok(Some(self.space_root_key.to_vec()))
     }
 
     pub async fn get_or_create_space_root_key(&self) -> Result<Vec<u8>> {
-        let space_root_key = self.space_root_key.clone();
-        *cache_lock(&self.space_root_key_cache, "space root key")? =
-            Some(Some(space_root_key.clone()));
-        Ok(space_root_key)
+        Ok(self.space_root_key.to_vec())
     }
 
     pub async fn list_owned_spaces(&self) -> Result<Vec<SpaceKeyResponse>> {
@@ -176,7 +180,7 @@ impl AccountSpaceCtx {
         let secret_key = decrypt_secretbox_payload(&self.space_root_key, &encrypted_secret_key)?;
         Ok(SpaceIdentity {
             public_key,
-            secret_key,
+            secret_key: SecretVec::new(secret_key),
         })
     }
 
@@ -338,7 +342,7 @@ impl AccountSpaceCtx {
             response.space_id.clone(),
             SpaceIdentity {
                 public_key,
-                secret_key,
+                secret_key: SecretVec::new(secret_key),
             },
         );
         Ok(CreatedSpace {
@@ -402,7 +406,7 @@ impl AccountSpaceCtx {
         &self,
         space_id: &str,
     ) -> Result<Option<ResolvedOwnedSpaceAccess>> {
-        let space_root_key = match self.get_space_root_key_cached().await? {
+        let space_root_key = match self.get_space_root_key().await? {
             Some(value) => value,
             None => return Ok(None),
         };
@@ -423,11 +427,11 @@ impl AccountSpaceCtx {
         space_id: &str,
     ) -> Result<Option<ResolvedSpaceAccess>> {
         let shares = self.list_all_decrypted_friend_shares().await?;
-        let Some(share) = shares.into_iter().find(|value| value.space_id == space_id) else {
+        let Some(mut share) = shares.into_iter().find(|value| value.space_id == space_id) else {
             return Ok(None);
         };
         Ok(Some(ResolvedSpaceAccess {
-            space_key: share.space_key,
+            space_key: std::mem::take(&mut share.space_key),
             key_version: share.key_version,
         }))
     }
@@ -450,11 +454,11 @@ impl AccountSpaceCtx {
         let shares = self
             .list_decrypted_friend_shares_cached(viewer_space_id)
             .await?;
-        let Some(share) = shares.into_iter().find(|value| value.space_id == space_id) else {
+        let Some(mut share) = shares.into_iter().find(|value| value.space_id == space_id) else {
             return Ok(None);
         };
         Ok(Some(ResolvedSpaceAccess {
-            space_key: share.space_key,
+            space_key: std::mem::take(&mut share.space_key),
             key_version: share.key_version,
         }))
     }
@@ -513,15 +517,6 @@ impl AccountSpaceCtx {
             .build_space_key_history_for_space_for_viewer(space_id, viewer_space_id)
             .await?;
         Ok(history.get(&target_version).cloned())
-    }
-
-    pub(crate) async fn get_space_root_key_cached(&self) -> Result<Option<Vec<u8>>> {
-        if let Some(value) = cache_lock(&self.space_root_key_cache, "space root key")?.clone() {
-            return Ok(value);
-        }
-        let value = self.get_space_root_key().await?;
-        *cache_lock(&self.space_root_key_cache, "space root key")? = Some(value.clone());
-        Ok(value)
     }
 
     pub(crate) async fn list_owned_spaces_cached(&self) -> Result<Vec<SpaceKeyResponse>> {
@@ -691,11 +686,12 @@ pub(super) fn build_api(
     client_package: Option<String>,
     client_version: Option<String>,
 ) -> Result<Api> {
+    let auth = space_session_token.map(Auth::SpaceSession);
     Ok(Api::new(
         Http::new()?,
         ApiConfig {
             origin: base_url.to_owned(),
-            auth: space_session_token.map(Auth::SpaceSession),
+            auth,
             user_agent,
             client_package,
             client_version,

--- a/rust/space/src/client/test_support.rs
+++ b/rust/space/src/client/test_support.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 use super::{AccountSpaceCtx, SpaceIdentity, cache_lock, generate_key, generate_keypair};
 use crate::crypto::encrypt_secretbox_payload;
 use crate::models::OpenAccountSpaceCtxInput;
-use ente_core::crypto::encode_b64;
+use ente_core::crypto::{SecretVec, encode_b64};
 
 /// A WEBP magic-number header, enough for the media sniffer to accept the bytes
 /// as a photo.
@@ -45,7 +45,7 @@ pub(crate) fn test_account_ctx_with_space_root_key(
             "space_owner_main".to_owned(),
             SpaceIdentity {
                 public_key,
-                secret_key,
+                secret_key: SecretVec::new(secret_key),
             },
         );
     ctx

--- a/rust/space/src/client/tests.rs
+++ b/rust/space/src/client/tests.rs
@@ -14,6 +14,22 @@ use crate::transport::{
 
 use mockito::{Matcher, Server};
 use serde_json::json;
+use zeroize::Zeroize;
+
+#[test]
+fn decrypted_friend_share_zeroizes_its_key() {
+    let mut share = DecryptedFriendShare {
+        friend: "friend@example.com".to_owned(),
+        space_id: "space-friend".to_owned(),
+        space_slug: "friend".to_owned(),
+        space_key: vec![42; 32],
+        key_version: 1,
+    };
+
+    share.zeroize();
+
+    assert!(share.space_key.is_empty());
+}
 
 #[tokio::test]
 async fn account_api_sends_space_session_token_header() {

--- a/rust/space/src/models.rs
+++ b/rust/space/src/models.rs
@@ -1,10 +1,11 @@
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
 
 use crate::transport::{
     PostObjectPayload, ProfileAvatarResponse, ProfileCoverResponse, SpaceActorResponse,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct OpenAccountSpaceCtxInput {
     pub base_url: String,
     pub space_session_token: Option<String>,
@@ -14,7 +15,7 @@ pub struct OpenAccountSpaceCtxInput {
     pub client_version: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CreatedSpace {
     pub space_id: String,
     pub space_slug: String,
@@ -36,7 +37,7 @@ pub struct DecryptedSpaceProfile {
     pub updated_at: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct DecryptedPost {
     pub post_key: Vec<u8>,
     pub caption_plaintext: Option<Vec<u8>>,
@@ -67,13 +68,14 @@ pub struct MessagePayload {
     pub text: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct DecryptedMessage {
     pub message_key: Vec<u8>,
     pub payload: MessagePayload,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Zeroize)]
+#[zeroize(drop)]
 pub struct DecryptedFriendShare {
     pub friend: String,
     pub space_id: String,
@@ -107,7 +109,7 @@ pub struct FeedPage {
     pub next_cursor: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct HydratedKeys {
     pub owned: Vec<(String, Vec<u8>)>,
     pub friends: Vec<DecryptedFriendShare>,

--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -980,7 +980,7 @@ func main() {
 	userEntityHandler := &api.UserEntityHandler{Controller: userEntityController}
 	spaceRepos := spacerepo.NewModule(db, s3Config)
 	userController.SpaceAccessResetter = spaceRepos
-	spaceModule := spacecontroller.NewModule(spaceRepos, userAuthRepo, &spacecontroller.SpaceEmailSender{UserRepo: userRepo})
+	spaceModule := spacecontroller.NewModule(spaceRepos, userAuthRepo, spacecontroller.NewSpaceEmailSender(userRepo))
 	spaceModule.Posts.AbuseNotifier = discordController
 	spaceDripController := spacecontroller.NewSpaceDripController(spaceRepos, userRepo, notificationHistoryRepo, lockController)
 	spaceModule.UserTokens = userController

--- a/server/space/api/sessions_test.go
+++ b/server/space/api/sessions_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -20,6 +21,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
+
+var testSpaceBrowserSessionWrapKey = base64.StdEncoding.EncodeToString(make([]byte, 32))
 
 type failingUserTokenTerminator struct{}
 
@@ -58,7 +61,7 @@ func TestCreateSpaceBrowserSessionReturnsTokenWhenCacheEvictionFails(t *testing.
 	require.NoError(t, (&baserepo.UserAuthRepository{DB: repos.Sessions.DB}).AddToken(userID, ente.Photos, authToken, "127.0.0.1", "space-test"))
 	router := gin.New()
 	router.POST("/account/space/sessions", handlers.CreateBrowserSession)
-	req := httptest.NewRequest(http.MethodPost, "/account/space/sessions", bytes.NewBufferString(`{"sessionWrapKey":"session-wrap-key"}`))
+	req := httptest.NewRequest(http.MethodPost, "/account/space/sessions", bytes.NewBufferString(`{"sessionWrapKey":"`+testSpaceBrowserSessionWrapKey+`"}`))
 	req.Header.Set("X-Auth-User-ID", strconv.FormatInt(userID, 10))
 	req.Header.Set("X-Auth-Token", authToken)
 	recorder := httptest.NewRecorder()
@@ -75,6 +78,36 @@ func TestCreateSpaceBrowserSessionReturnsTokenWhenCacheEvictionFails(t *testing.
 	session, err := repos.Sessions.GetBrowserSession(context.Background(), tokenHash[:])
 	require.NoError(t, err)
 	require.Equal(t, userID, session.UserID)
+	require.Equal(t, testSpaceBrowserSessionWrapKey, session.SessionWrapKey)
+}
+
+func TestCreateSpaceBrowserSessionRejectsInvalidWrapKey(t *testing.T) {
+	handlers, repos, userID := setupSpaceSessionAPITest(t)
+	router := gin.New()
+	router.POST("/account/space/sessions", handlers.CreateBrowserSession)
+
+	for _, tt := range []struct {
+		name string
+		key  string
+	}{
+		{name: "invalid base64", key: testSpaceBrowserSessionWrapKey[:len(testSpaceBrowserSessionWrapKey)-1] + "!"},
+		{name: "wrong decoded length", key: base64.StdEncoding.EncodeToString(make([]byte, 31))},
+		{name: "too long", key: testSpaceBrowserSessionWrapKey + "A"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/account/space/sessions", bytes.NewBufferString(`{"sessionWrapKey":"`+tt.key+`"}`))
+			req.Header.Set("X-Auth-User-ID", strconv.FormatInt(userID, 10))
+			recorder := httptest.NewRecorder()
+
+			router.ServeHTTP(recorder, req)
+
+			require.Equal(t, http.StatusBadRequest, recorder.Code)
+		})
+	}
+
+	var count int
+	require.NoError(t, repos.Sessions.DB.QueryRow(`SELECT COUNT(*) FROM space_browser_sessions WHERE user_id = $1`, userID).Scan(&count))
+	require.Zero(t, count)
 }
 
 func TestRegisteredTokenSessionRoutesAllowSessionCreationBeforeBrowserSession(t *testing.T) {
@@ -91,7 +124,7 @@ func TestRegisteredTokenSessionRoutesAllowSessionCreationBeforeBrowserSession(t 
 	sessionReq := httptest.NewRequest(
 		http.MethodPost,
 		"/account/space/sessions",
-		bytes.NewBufferString(`{"sessionWrapKey":"session-wrap-key"}`),
+		bytes.NewBufferString(`{"sessionWrapKey":"`+testSpaceBrowserSessionWrapKey+`"}`),
 	)
 	sessionReq.Header.Set("X-Auth-User-ID", strconv.FormatInt(userID, 10))
 	sessionReq.Header.Set("X-Auth-Token", authToken)

--- a/server/space/controller/friends.go
+++ b/server/space/controller/friends.go
@@ -63,12 +63,12 @@ func (c *FriendsController) Add(ctx context.Context, requesterSpace *repo.SpaceR
 	}
 	if becameFriends {
 		if c.EmailNotifier != nil {
-			go c.EmailNotifier.OnSpaceFriendAdded(requesterSpace.SpaceSlug, request.RequesterID)
+			go c.EmailNotifier.OnSpaceFriendAdded(requesterSpace.OwnerID, requesterSpace.SpaceSlug, request.RequesterID)
 		}
 		return &models.FriendStatusResponse{Status: "friend"}, nil
 	}
 	if created && c.EmailNotifier != nil {
-		go c.EmailNotifier.OnSpaceFriendRequested(requesterSpace.SpaceSlug, request.TargetID)
+		go c.EmailNotifier.OnSpaceFriendRequested(requesterSpace.OwnerID, requesterSpace.SpaceSlug, request.TargetID)
 	}
 	return &models.FriendStatusResponse{Status: "requested"}, nil
 }
@@ -111,7 +111,7 @@ func (c *FriendsController) ConfirmRequest(ctx context.Context, targetSpace *rep
 		return nil, err
 	}
 	if created && c.EmailNotifier != nil {
-		go c.EmailNotifier.OnSpaceFriendAdded(targetSpace.SpaceSlug, requesterID)
+		go c.EmailNotifier.OnSpaceFriendAdded(targetSpace.OwnerID, targetSpace.SpaceSlug, requesterID)
 	}
 	return &models.FriendStatusResponse{Status: "friend"}, nil
 }

--- a/server/space/controller/messages.go
+++ b/server/space/controller/messages.go
@@ -119,7 +119,7 @@ func (c *MessagesController) ReplyToPost(ctx context.Context, senderSpace *repo.
 		return nil, err
 	}
 	if c.EmailNotifier != nil {
-		go c.EmailNotifier.OnSpacePostReplied(senderSpace.SpaceSlug, recipientSpace.OwnerID)
+		go c.EmailNotifier.OnSpacePostReplied(senderSpace.OwnerID, senderSpace.SpaceSlug, recipientSpace.OwnerID)
 	}
 	return toMessageResponse(*message), nil
 }

--- a/server/space/controller/notifications.go
+++ b/server/space/controller/notifications.go
@@ -1,13 +1,17 @@
 package controller
 
 import (
+	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	baserepo "github.com/ente/museum/pkg/repo"
+	util "github.com/ente/museum/pkg/utils"
 	emailutil "github.com/ente/museum/pkg/utils/email"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+	"github.com/ulule/limiter/v3"
 )
 
 const (
@@ -25,43 +29,52 @@ const (
 	spaceNewPostLikeIllustrationWidth  = 132
 	spaceNewPostReplyIllustrationWidth = 132
 	spaceNewFriendIllustrationWidth    = 220
+	spaceEmailSendRate                 = "50-H"
 )
 
 var sendSpaceNotificationEmail = emailutil.SendTemplatedEmail
 
 type SpaceEmailNotifier interface {
-	OnSpacePostCreated(authorSlug string, recipientUserIDs []int64)
-	OnSpacePostLiked(actorSlug string, recipientUserID int64)
-	OnSpacePostReplied(actorSlug string, recipientUserID int64)
-	OnSpaceFriendAdded(actorSlug string, recipientUserID int64)
-	OnSpaceFriendRequested(actorSlug string, recipientUserID int64)
+	OnSpacePostCreated(actorUserID int64, actorSlug string, recipientUserIDs []int64)
+	OnSpacePostLiked(actorUserID int64, actorSlug string, recipientUserID int64)
+	OnSpacePostReplied(actorUserID int64, actorSlug string, recipientUserID int64)
+	OnSpaceFriendAdded(actorUserID int64, actorSlug string, recipientUserID int64)
+	OnSpaceFriendRequested(actorUserID int64, actorSlug string, recipientUserID int64)
 }
 
 type SpaceEmailSender struct {
-	UserRepo *baserepo.UserRepository
+	UserRepo    *baserepo.UserRepository
+	sendLimiter *limiter.Limiter
 }
 
-func (n *SpaceEmailSender) OnSpacePostCreated(authorSlug string, recipientUserIDs []int64) {
-	n.send(authorSlug, "posted a new photo", spaceNotificationPostCreated, recipientUserIDs)
+func NewSpaceEmailSender(userRepo *baserepo.UserRepository) *SpaceEmailSender {
+	return &SpaceEmailSender{
+		UserRepo:    userRepo,
+		sendLimiter: util.NewRateLimiter(spaceEmailSendRate),
+	}
 }
 
-func (n *SpaceEmailSender) OnSpacePostLiked(actorSlug string, recipientUserID int64) {
-	n.send(actorSlug, "liked your post", spaceNotificationPostLiked, []int64{recipientUserID})
+func (n *SpaceEmailSender) OnSpacePostCreated(actorUserID int64, actorSlug string, recipientUserIDs []int64) {
+	n.send(actorUserID, actorSlug, "posted a new photo", spaceNotificationPostCreated, recipientUserIDs)
 }
 
-func (n *SpaceEmailSender) OnSpacePostReplied(actorSlug string, recipientUserID int64) {
-	n.send(actorSlug, "replied to your post", spaceNotificationPostReplied, []int64{recipientUserID})
+func (n *SpaceEmailSender) OnSpacePostLiked(actorUserID int64, actorSlug string, recipientUserID int64) {
+	n.send(actorUserID, actorSlug, "liked your post", spaceNotificationPostLiked, []int64{recipientUserID})
 }
 
-func (n *SpaceEmailSender) OnSpaceFriendAdded(actorSlug string, recipientUserID int64) {
-	n.send(actorSlug, "is now your friend", spaceNotificationFriendAdded, []int64{recipientUserID})
+func (n *SpaceEmailSender) OnSpacePostReplied(actorUserID int64, actorSlug string, recipientUserID int64) {
+	n.send(actorUserID, actorSlug, "replied to your post", spaceNotificationPostReplied, []int64{recipientUserID})
 }
 
-func (n *SpaceEmailSender) OnSpaceFriendRequested(actorSlug string, recipientUserID int64) {
-	n.send(actorSlug, "sent you a friend request", spaceNotificationFriendRequested, []int64{recipientUserID})
+func (n *SpaceEmailSender) OnSpaceFriendAdded(actorUserID int64, actorSlug string, recipientUserID int64) {
+	n.send(actorUserID, actorSlug, "is now your friend", spaceNotificationFriendAdded, []int64{recipientUserID})
 }
 
-func (n *SpaceEmailSender) send(actorSlug, action, event string, recipientUserIDs []int64) {
+func (n *SpaceEmailSender) OnSpaceFriendRequested(actorUserID int64, actorSlug string, recipientUserID int64) {
+	n.send(actorUserID, actorSlug, "sent you a friend request", spaceNotificationFriendRequested, []int64{recipientUserID})
+}
+
+func (n *SpaceEmailSender) send(actorUserID int64, actorSlug, action, event string, recipientUserIDs []int64) {
 	if n == nil || n.UserRepo == nil || len(recipientUserIDs) == 0 {
 		return
 	}
@@ -87,6 +100,20 @@ func (n *SpaceEmailSender) send(actorSlug, action, event string, recipientUserID
 		user := users[userID]
 		if user == nil || strings.TrimSpace(user.Email) == "" {
 			continue
+		}
+		limitContext, err := n.sendLimiter.Get(context.Background(), strconv.FormatInt(actorUserID, 10))
+		if err != nil {
+			log.WithField("actor_user_id", actorUserID).WithError(err).Error("Error checking space email rate limit")
+			continue
+		}
+		if limitContext.Reached {
+			continue
+		}
+		if limitContext.Remaining == 0 {
+			log.WithFields(log.Fields{
+				"actor_user_id": actorUserID,
+				"reset_at":      limitContext.Reset,
+			}).Warn("Space email rate limit reached")
 		}
 		if err := sendSpaceNotificationEmail(
 			[]string{user.Email},

--- a/server/space/controller/notifications_test.go
+++ b/server/space/controller/notifications_test.go
@@ -2,17 +2,23 @@ package controller
 
 import (
 	"encoding/base64"
+	"io"
 	"testing"
 	"time"
 
+	"github.com/ente/museum/internal/testutil"
+	baserepo "github.com/ente/museum/pkg/repo"
 	"github.com/ente/museum/space/models"
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 )
 
 type recordedSpaceEmail struct {
-	event      string
-	actorSlug  string
-	recipients []int64
+	event       string
+	actorUserID int64
+	actorSlug   string
+	recipients  []int64
 }
 
 type recordingSpaceEmailNotifier struct {
@@ -23,24 +29,24 @@ func newRecordingSpaceEmailNotifier() *recordingSpaceEmailNotifier {
 	return &recordingSpaceEmailNotifier{events: make(chan recordedSpaceEmail, 8)}
 }
 
-func (n *recordingSpaceEmailNotifier) OnSpacePostCreated(actorSlug string, recipientUserIDs []int64) {
-	n.events <- recordedSpaceEmail{event: "post_created", actorSlug: actorSlug, recipients: append([]int64(nil), recipientUserIDs...)}
+func (n *recordingSpaceEmailNotifier) OnSpacePostCreated(actorUserID int64, actorSlug string, recipientUserIDs []int64) {
+	n.events <- recordedSpaceEmail{event: "post_created", actorUserID: actorUserID, actorSlug: actorSlug, recipients: append([]int64(nil), recipientUserIDs...)}
 }
 
-func (n *recordingSpaceEmailNotifier) OnSpacePostLiked(actorSlug string, recipientUserID int64) {
-	n.events <- recordedSpaceEmail{event: "post_liked", actorSlug: actorSlug, recipients: []int64{recipientUserID}}
+func (n *recordingSpaceEmailNotifier) OnSpacePostLiked(actorUserID int64, actorSlug string, recipientUserID int64) {
+	n.events <- recordedSpaceEmail{event: "post_liked", actorUserID: actorUserID, actorSlug: actorSlug, recipients: []int64{recipientUserID}}
 }
 
-func (n *recordingSpaceEmailNotifier) OnSpacePostReplied(actorSlug string, recipientUserID int64) {
-	n.events <- recordedSpaceEmail{event: "post_replied", actorSlug: actorSlug, recipients: []int64{recipientUserID}}
+func (n *recordingSpaceEmailNotifier) OnSpacePostReplied(actorUserID int64, actorSlug string, recipientUserID int64) {
+	n.events <- recordedSpaceEmail{event: "post_replied", actorUserID: actorUserID, actorSlug: actorSlug, recipients: []int64{recipientUserID}}
 }
 
-func (n *recordingSpaceEmailNotifier) OnSpaceFriendAdded(actorSlug string, recipientUserID int64) {
-	n.events <- recordedSpaceEmail{event: "friend_added", actorSlug: actorSlug, recipients: []int64{recipientUserID}}
+func (n *recordingSpaceEmailNotifier) OnSpaceFriendAdded(actorUserID int64, actorSlug string, recipientUserID int64) {
+	n.events <- recordedSpaceEmail{event: "friend_added", actorUserID: actorUserID, actorSlug: actorSlug, recipients: []int64{recipientUserID}}
 }
 
-func (n *recordingSpaceEmailNotifier) OnSpaceFriendRequested(actorSlug string, recipientUserID int64) {
-	n.events <- recordedSpaceEmail{event: "friend_requested", actorSlug: actorSlug, recipients: []int64{recipientUserID}}
+func (n *recordingSpaceEmailNotifier) OnSpaceFriendRequested(actorUserID int64, actorSlug string, recipientUserID int64) {
+	n.events <- recordedSpaceEmail{event: "friend_requested", actorUserID: actorUserID, actorSlug: actorSlug, recipients: []int64{recipientUserID}}
 }
 
 func requireSpaceEmail(t *testing.T, notifier *recordingSpaceEmailNotifier) recordedSpaceEmail {
@@ -89,6 +95,51 @@ func TestSpaceEmailTemplateData(t *testing.T) {
 	require.Equal(t, spaceNewFriendIllustrationWidth, spaceEmailIllustrationWidth(spaceNotificationFriendRequested))
 }
 
+func TestSpaceEmailSenderLimitsEachSenderToFiftyEmailsPerHour(t *testing.T) {
+	_, repos, _ := setupPostsControllerTest(t)
+	recipientID := insertSpaceControllerUser(t, repos, "space-email-limit-recipient@example.com", "recipient-public")
+	otherRecipientID := insertSpaceControllerUser(t, repos, "space-email-limit-other-recipient@example.com", "other-recipient-public")
+	sender := NewSpaceEmailSender(&baserepo.UserRepository{
+		DB:                  repos.Spaces.DB,
+		SecretEncryptionKey: testutil.SecretEncryptionKey(),
+	})
+	logger := log.StandardLogger()
+	originalHooks := logger.ReplaceHooks(make(log.LevelHooks))
+	originalOutput := logger.Out
+	logger.SetOutput(io.Discard)
+	hook := logtest.NewGlobal()
+	t.Cleanup(func() {
+		logger.ReplaceHooks(originalHooks)
+		logger.SetOutput(originalOutput)
+		hook.Reset()
+	})
+
+	originalSend := sendSpaceNotificationEmail
+	t.Cleanup(func() {
+		sendSpaceNotificationEmail = originalSend
+	})
+	sent := 0
+	sendSpaceNotificationEmail = func(_ []string, _ string, _ string, _ string, _ string, _ map[string]interface{}, _ []map[string]interface{}) error {
+		sent++
+		return nil
+	}
+
+	for range 50 {
+		sender.OnSpacePostReplied(1, "alice", recipientID)
+	}
+	require.Equal(t, 50, sent)
+
+	sender.OnSpacePostLiked(1, "alice", otherRecipientID)
+	require.Equal(t, 50, sent)
+	require.Len(t, hook.AllEntries(), 1)
+	require.Equal(t, log.WarnLevel, hook.LastEntry().Level)
+	require.Equal(t, "Space email rate limit reached", hook.LastEntry().Message)
+	require.Equal(t, int64(1), hook.LastEntry().Data["actor_user_id"])
+
+	sender.OnSpaceFriendRequested(2, "bob", recipientID)
+	require.Equal(t, 51, sent)
+}
+
 func TestPostLikeSendsEmailOnce(t *testing.T) {
 	_, repos, ctx := setupPostsControllerTest(t)
 	notifier := newRecordingSpaceEmailNotifier()
@@ -107,7 +158,7 @@ func TestPostLikeSendsEmailOnce(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, resp.Liked)
 	email := requireSpaceEmail(t, notifier)
-	require.Equal(t, recordedSpaceEmail{event: "post_liked", actorSlug: bobSpace.SpaceSlug, recipients: []int64{aliceID}}, email)
+	require.Equal(t, recordedSpaceEmail{event: "post_liked", actorUserID: bobID, actorSlug: bobSpace.SpaceSlug, recipients: []int64{aliceID}}, email)
 
 	_, err = posts.SetLike(ctx, bobSpace, postID, true)
 	require.NoError(t, err)
@@ -131,7 +182,7 @@ func TestPostReplySendsEmail(t *testing.T) {
 	})
 	require.NoError(t, err)
 	email := requireSpaceEmail(t, notifier)
-	require.Equal(t, recordedSpaceEmail{event: "post_replied", actorSlug: bobSpace.SpaceSlug, recipients: []int64{aliceID}}, email)
+	require.Equal(t, recordedSpaceEmail{event: "post_replied", actorUserID: bobID, actorSlug: bobSpace.SpaceSlug, recipients: []int64{aliceID}}, email)
 }
 
 func TestAddFriendSendsEmailOnce(t *testing.T) {
@@ -154,7 +205,7 @@ func TestAddFriendSendsEmailOnce(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "requested", resp.Status)
 	email := requireSpaceEmail(t, notifier)
-	require.Equal(t, recordedSpaceEmail{event: "friend_requested", actorSlug: bobSpace.SpaceSlug, recipients: []int64{aliceID}}, email)
+	require.Equal(t, recordedSpaceEmail{event: "friend_requested", actorUserID: bobID, actorSlug: bobSpace.SpaceSlug, recipients: []int64{aliceID}}, email)
 
 	_, err = friends.Add(ctx, bobSpace, req)
 	require.NoError(t, err)
@@ -172,5 +223,5 @@ func TestAddFriendSendsEmailOnce(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "friend", resp.Status)
 	email = requireSpaceEmail(t, notifier)
-	require.Equal(t, recordedSpaceEmail{event: "friend_added", actorSlug: aliceSpace.SpaceSlug, recipients: []int64{bobID}}, email)
+	require.Equal(t, recordedSpaceEmail{event: "friend_added", actorUserID: aliceID, actorSlug: aliceSpace.SpaceSlug, recipients: []int64{bobID}}, email)
 }

--- a/server/space/controller/posts.go
+++ b/server/space/controller/posts.go
@@ -92,11 +92,11 @@ func (c *PostsController) Create(ctx context.Context, space *repo.SpaceRecord, r
 			space.SpaceID, space.OwnerID, postCount, repo.MaxPostsPerSpace,
 		))
 	}
-	c.notifyFriendsOfNewPost(space.SpaceID, space.SpaceSlug)
+	c.notifyFriendsOfNewPost(space.OwnerID, space.SpaceID, space.SpaceSlug)
 	return &models.CreatePostResponse{PostID: postID}, nil
 }
 
-func (c *PostsController) notifyFriendsOfNewPost(spaceID, spaceSlug string) {
+func (c *PostsController) notifyFriendsOfNewPost(ownerID int64, spaceID, spaceSlug string) {
 	if c.EmailNotifier == nil || c.FriendsRepo == nil {
 		return
 	}
@@ -109,7 +109,7 @@ func (c *PostsController) notifyFriendsOfNewPost(spaceID, spaceSlug string) {
 		if len(recipientUserIDs) == 0 {
 			return
 		}
-		c.EmailNotifier.OnSpacePostCreated(spaceSlug, recipientUserIDs)
+		c.EmailNotifier.OnSpacePostCreated(ownerID, spaceSlug, recipientUserIDs)
 	}()
 }
 
@@ -243,7 +243,7 @@ func (c *PostsController) SetLike(ctx context.Context, actorSpace *repo.SpaceRec
 		return nil, err
 	}
 	if like && created && c.EmailNotifier != nil {
-		go c.EmailNotifier.OnSpacePostLiked(actorSpace.SpaceSlug, post.OwnerID)
+		go c.EmailNotifier.OnSpacePostLiked(actorSpace.OwnerID, actorSpace.SpaceSlug, post.OwnerID)
 	}
 	return &models.LikePostResponse{Liked: like}, nil
 }

--- a/server/space/controller/posts_test.go
+++ b/server/space/controller/posts_test.go
@@ -42,6 +42,20 @@ func TestCreatePostRequiresAssetMetadataCipher(t *testing.T) {
 	require.Contains(t, err.Error(), "metadataCipher is required")
 }
 
+func TestCreatePostRejectsMultipleObjects(t *testing.T) {
+	controller := &PostsController{}
+
+	_, err := controller.Create(t.Context(), &spacerepo.SpaceRecord{}, models.CreatePostRequest{
+		EncryptedPostKey: "post-key",
+		Objects: []models.PostObjectPayload{
+			{ObjectKey: "first"},
+			{ObjectKey: "second"},
+		},
+	})
+
+	require.ErrorContains(t, err, "too many post objects")
+}
+
 func TestListPostsHydratesPostAssets(t *testing.T) {
 	controller, repos, ctx := setupPostsControllerTest(t)
 	aliceID := insertSpaceControllerUser(t, repos, "alice-list-assets@example.com", "alice-public")

--- a/server/space/controller/sessions.go
+++ b/server/space/controller/sessions.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"crypto/sha256"
 	"database/sql"
+	"encoding/base64"
 	"errors"
 	"strings"
 
@@ -18,6 +19,7 @@ import (
 const (
 	spaceBrowserSessionDurationDays = 365
 	spaceBrowserSessionTouchMinutes = 1
+	spaceBrowserSessionWrapKeyBytes = 32
 )
 const SpaceBrowserSessionTokenHeader = "X-Space-Session-Token"
 
@@ -30,11 +32,15 @@ type CreatedBrowserSession struct {
 }
 
 func (c *SessionsController) CreateBrowserSession(ctx *gin.Context, userID int64, authToken string, sessionWrapKey string) (*CreatedBrowserSession, error) {
-	sessionToken := auth.GenerateURLSafeRandomString(32)
 	sessionWrapKey = strings.TrimSpace(sessionWrapKey)
-	if sessionWrapKey == "" {
-		return nil, ente.NewBadRequestWithMessage("sessionWrapKey is required")
+	if len(sessionWrapKey) != base64.StdEncoding.EncodedLen(spaceBrowserSessionWrapKeyBytes) {
+		return nil, ente.NewBadRequestWithMessage("sessionWrapKey must be a base64-encoded 32-byte key")
 	}
+	decodedWrapKey, err := base64.StdEncoding.DecodeString(sessionWrapKey)
+	if err != nil || len(decodedWrapKey) != spaceBrowserSessionWrapKeyBytes {
+		return nil, ente.NewBadRequestWithMessage("sessionWrapKey must be a base64-encoded 32-byte key")
+	}
+	sessionToken := auth.GenerateURLSafeRandomString(32)
 	sessionHash := sha256.Sum256([]byte(sessionToken))
 	expiresAt := timeutil.NDaysFromNow(spaceBrowserSessionDurationDays)
 	if err := c.SessionsRepo.ExchangeBrowserSession(ctx, authToken, sessionHash[:], userID, sessionWrapKey, expiresAt); err != nil {

--- a/server/space/controller/validation.go
+++ b/server/space/controller/validation.go
@@ -19,7 +19,7 @@ const (
 	maxSpaceCaptionCipherDecodedBytes    = 12 * 1024
 	maxSpaceAssetMetadataEncodedBytes    = 8 * 1024
 	maxSpaceAssetMetadataDecodedBytes    = 6 * 1024
-	maxSpacePostObjects                  = 10
+	maxSpacePostObjects                  = 1
 	maxSpaceFriendSharesPerRefresh       = 500
 	maxSpaceObjectKeyBytes               = 512
 )


### PR DESCRIPTION
- Validate browser session wrap keys as base64-encoded 32-byte keys.
- Zeroize sensitive Space key material and prevent accidental debug exposure.
- Restrict Space posts to one object.
- Limit notification emails to 50 per sender per hour.