### PR TITLE
[space] Fix Space drip scheduling and login notification labels

### DIFF
--- a/server/cmd/museum/main.go
+++ b/server/cmd/museum/main.go
@@ -1374,7 +1374,7 @@ func setupAndStartCrons(userAuthRepo *repo.UserAuthRepository, collectionLinkRep
 		emailNotificationCtrl.SendStorageWarningMails()
 	})
 
-	schedule(c, "@every 24h", func() {
+	scheduleAndRun(c, "@every 24h", func() {
 		spaceDripController.ProcessSpaceDrips()
 	})
 

--- a/server/pkg/controller/user/userauth.go
+++ b/server/pkg/controller/user/userauth.go
@@ -1,7 +1,6 @@
 package user
 
 import (
-	"context"
 	"database/sql"
 	"encoding/base64"
 	"errors"
@@ -506,7 +505,7 @@ func (c *UserController) ClearStorageWarningDeletionLoginBlock(userID int64) err
 	return c.NotificationHistoryRepo.ClearStorageWarningDeletionScheduled(userID)
 }
 
-func (c *UserController) AddTokenAndNotify(ctx context.Context, userID int64, app ente.App, token string, ip string, userAgent string) error {
+func (c *UserController) AddTokenAndNotify(ctx *gin.Context, userID int64, app ente.App, token string, ip string, userAgent string) error {
 	if err := c.ensureStorageWarningDeletionLoginAllowed(userID, app); err != nil {
 		return err
 	}
@@ -522,6 +521,7 @@ func (c *UserController) AddTokenAndNotify(ctx context.Context, userID int64, ap
 		return nil
 	}
 
+	clientPackage := ctx.GetHeader("X-Client-Package")
 	go func() {
 		user, userErr := c.UserRepo.GetUserByIDInternal(userID)
 		if userErr != nil {
@@ -540,6 +540,9 @@ func (c *UserController) AddTokenAndNotify(ctx context.Context, userID int64, ap
 			appName, ok := appDisplayNames[app]
 			if !ok {
 				appName = "Ente"
+			}
+			if clientPackage == "io.ente.space.web" {
+				appName = "Ente Space"
 			}
 			device := "Unknown Device"
 			if strings.TrimSpace(userAgent) != "" {

--- a/server/space/controller/drips.go
+++ b/server/space/controller/drips.go
@@ -65,9 +65,10 @@ func (c *SpaceDripController) ProcessSpaceDrips() {
 	}
 	if c.LockController != nil {
 		if !c.LockController.TryLock(spaceDripMailLock, timeutil.MicrosecondsAfterHours(24)) {
-			log.Info("Skipping space drip emails because the daily lock is held")
+			log.Info("Skipping space drip emails because another instance is running")
 			return
 		}
+		defer c.LockController.ReleaseLock(spaceDripMailLock)
 	}
 	stats, err := c.processSpaceDrips(context.Background(), timeutil.Microseconds())
 	if err != nil {
@@ -168,6 +169,12 @@ func (c *SpaceDripController) processSpaceDripStage(ctx context.Context, stage s
 	candidates, err := stage.Candidates(ctx, now, limit)
 	if err != nil {
 		return 0, err
+	}
+	if len(candidates) == limit {
+		log.WithFields(log.Fields{
+			"template_id": stage.TemplateID,
+			"batch_size":  limit,
+		}).Warn("Space drip candidate batch reached limit")
 	}
 	userIDs := make([]int64, 0, len(candidates))
 	for _, candidate := range candidates {

--- a/server/space/controller/drips_test.go
+++ b/server/space/controller/drips_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProcessSpaceDripsKeepsDailyLock(t *testing.T) {
+func TestProcessSpaceDripsReleasesLock(t *testing.T) {
 	testutil.WithServerRoot(t)
 	db := testutil.RequireTestDB(t)
 	testutil.ResetTables(t, db)
@@ -38,9 +38,9 @@ func TestProcessSpaceDripsKeepsDailyLock(t *testing.T) {
 
 	controller.ProcessSpaceDrips()
 
-	var lockUntil int64
-	require.NoError(t, db.QueryRow(`SELECT lock_until FROM task_lock WHERE task_name = $1`, spaceDripMailLock).Scan(&lockUntil))
-	require.Greater(t, lockUntil, timeutil.Microseconds())
+	var lockCount int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM task_lock WHERE task_name = $1`, spaceDripMailLock).Scan(&lockCount))
+	require.Zero(t, lockCount)
 }
 
 func TestSpaceDripsSendMatureProfileNudgeOnly(t *testing.T) {


### PR DESCRIPTION
- run Space drip processing on startup and release its distributed lock after each run
- warn when a drip candidate batch reaches its configured limit
- label Space web logins as Ente Space in login notification emails