### PR TITLE
Split Space WASM bindings into dedicated package

### DIFF
--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -82,7 +82,7 @@ jobs:
             - run: cargo clippy -p ente_rust --features flutter --all-targets --locked
 
     rust-wasm:
-        # For web-lint.yml's npm run build:wasm.
+        # For web-lint.yml's WASM builds.
         runs-on: ubuntu-latest
         defaults:
             run:
@@ -107,6 +107,8 @@ jobs:
             - run: npm ci
 
             - run: npm run build:wasm
+
+            - run: npm run build:space-wasm
 
     rust-cli:
         # For rust-e2e-test.yml.

--- a/.github/workflows/web-lint.yml
+++ b/.github/workflows/web-lint.yml
@@ -6,6 +6,7 @@ on:
         paths:
             - "web/**"
             - "rust/bindings/wasm/ente-wasm/**"
+            - "rust/bindings/wasm/space/**"
             - "rust/space/**"
             - "rust/crates/contacts/**"
             - "rust/crates/core/**"
@@ -51,6 +52,8 @@ jobs:
             - run: npm audit --audit-level critical
 
             - run: npm run build:wasm
+
+            - run: npm run build:space-wasm
 
             - run: npm run lint
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2542,6 +2542,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ente-space-wasm"
+version = "0.0.0"
+dependencies = [
+ "ente-core",
+ "ente-space",
+ "serde",
+ "serde-wasm-bindgen",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "ente-test-support"
 version = "0.0.0"
 dependencies = [
@@ -2556,7 +2568,6 @@ version = "0.0.0"
 dependencies = [
  "ente-contacts",
  "ente-core",
- "ente-space",
  "js-sys",
  "md-5 0.11.0",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "bindings/uniffi/ensu",
     "bindings/wasm/ente-wasm",
     "bindings/wasm/core",
+    "bindings/wasm/space",
     "crates/accounts",
     "crates/contacts",
     "crates/core",

--- a/rust/bindings/wasm/ente-wasm/src/lib.rs
+++ b/rust/bindings/wasm/ente-wasm/src/lib.rs
@@ -4,5 +4,4 @@ mod auth;
 mod contacts;
 mod crypto;
 mod legacy_kit;
-mod space;
 mod urls;

--- a/rust/bindings/wasm/space/Cargo.toml
+++ b/rust/bindings/wasm/space/Cargo.toml
@@ -1,15 +1,13 @@
 [package]
-name = "ente-wasm"
+name = "ente-space-wasm"
 edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-ente-contacts.workspace = true
-ente-core = { workspace = true, features = ["srp"] }
-md-5 = "0.11"
-js-sys = "0.3"
+ente-core.workspace = true
+ente-space.workspace = true
 serde.workspace = true
 serde-wasm-bindgen = "0.6"
 wasm-bindgen.workspace = true

--- a/rust/bindings/wasm/space/src/lib.rs
+++ b/rust/bindings/wasm/space/src/lib.rs
@@ -1,0 +1,3 @@
+//! WASM bindings for Ente Space.
+
+mod space;

--- a/rust/bindings/wasm/space/src/space.rs
+++ b/rust/bindings/wasm/space/src/space.rs
@@ -1,4 +1,4 @@
-//! WASM bindings for space flows.
+//! WASM bindings for Space flows.
 
 use std::collections::BTreeMap;
 
@@ -484,7 +484,7 @@ async fn message_conversation_activity_to_js(
 }
 
 /// Open an authenticated space context for web.
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = spaceOpenAccountCtx)]
 pub async fn space_open_account_ctx(
     input: JsValue,
 ) -> Result<SpaceAccountCtxHandle, WasmSpaceError> {
@@ -510,6 +510,7 @@ pub struct SpaceAccountCtxHandle {
 #[wasm_bindgen]
 impl SpaceAccountCtxHandle {
     /// Create a space with an encrypted JSON profile payload.
+    #[wasm_bindgen(js_name = createSpace)]
     pub async fn create_space(
         &self,
         space_slug: String,
@@ -529,11 +530,13 @@ impl SpaceAccountCtxHandle {
     }
 
     /// List spaces owned by the current account.
+    #[wasm_bindgen(js_name = listOwnedSpaces)]
     pub async fn list_owned_spaces(&self) -> Result<JsValue, WasmSpaceError> {
         swb::to_value(&self.inner.list_owned_spaces().await?).map_err(Into::into)
     }
 
     /// Fetch and decrypt a space profile.
+    #[wasm_bindgen(js_name = getSpaceProfile)]
     pub async fn get_space_profile(
         &self,
         space_id: String,
@@ -548,6 +551,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Update a space's encrypted JSON profile payload.
+    #[wasm_bindgen(js_name = updateSpaceProfile)]
     pub async fn update_space_profile(
         &self,
         space_id: String,
@@ -563,6 +567,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Update a space profile and replace its encrypted avatar asset.
+    #[wasm_bindgen(js_name = updateSpaceProfileWithAvatar)]
     pub async fn update_space_profile_with_avatar(
         &self,
         space_id: String,
@@ -592,6 +597,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Update a space profile and replace its encrypted cover asset.
+    #[wasm_bindgen(js_name = updateSpaceProfileWithCover)]
     pub async fn update_space_profile_with_cover(
         &self,
         space_id: String,
@@ -628,6 +634,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Update a space's slug.
+    #[wasm_bindgen(js_name = updateSpaceSlug)]
     pub async fn update_space_slug(
         &self,
         space_id: String,
@@ -638,6 +645,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Lookup public space metadata by slug.
+    #[wasm_bindgen(js_name = lookupSpaceBySlug)]
     pub async fn lookup_space_by_slug(
         &self,
         space_slug: String,
@@ -646,6 +654,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Return whether the target space is self, friend, or neither.
+    #[wasm_bindgen(js_name = getRelationship)]
     pub async fn get_relationship(
         &self,
         space_id: String,
@@ -661,6 +670,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Request to add a public username as a friend.
+    #[wasm_bindgen(js_name = requestFriendByUsername)]
     pub async fn request_friend_by_username(
         &self,
         space_id: String,
@@ -676,6 +686,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// List the current account feed with captions decrypted.
+    #[wasm_bindgen(js_name = listFeed)]
     pub async fn list_feed(
         &self,
         space_id: String,
@@ -712,11 +723,13 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Return whether the current account has unread notification activity.
+    #[wasm_bindgen(js_name = unreadStatus)]
     pub async fn unread_status(&self, space_id: String) -> Result<JsValue, WasmSpaceError> {
         swb::to_value(&self.inner.unread_status(&space_id).await?).map_err(Into::into)
     }
 
     /// Mark notification activity for one friend as read.
+    #[wasm_bindgen(js_name = markNotificationsRead)]
     pub async fn mark_notifications_read(
         &self,
         space_id: String,
@@ -732,6 +745,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// List posts on a space with captions decrypted.
+    #[wasm_bindgen(js_name = listPosts)]
     pub async fn list_posts(
         &self,
         space_id: String,
@@ -752,6 +766,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Fetch one post with its caption decrypted.
+    #[wasm_bindgen(js_name = getPost)]
     pub async fn get_post(
         &self,
         space_id: String,
@@ -778,6 +793,7 @@ impl SpaceAccountCtxHandle {
 
     /// Create a single-photo post with optional caption.
     #[allow(clippy::too_many_arguments)]
+    #[wasm_bindgen(js_name = createPhotoPost)]
     pub async fn create_photo_post(
         &self,
         space_id: String,
@@ -824,6 +840,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Download and decrypt one object from a space post.
+    #[wasm_bindgen(js_name = downloadPostAsset)]
     pub async fn download_post_asset(
         &self,
         space_id: String,
@@ -838,6 +855,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Download and decrypt one object from an already fetched space post.
+    #[wasm_bindgen(js_name = downloadPostAssetWithKey)]
     pub async fn download_post_asset_with_key(
         &self,
         space_id: String,
@@ -859,6 +877,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Download and decrypt a space avatar using an owned or friend space key.
+    #[wasm_bindgen(js_name = downloadSpaceAvatar)]
     pub async fn download_space_avatar(
         &self,
         space_id: String,
@@ -879,6 +898,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Download and decrypt a space cover using an owned or friend space key.
+    #[wasm_bindgen(js_name = downloadSpaceCover)]
     pub async fn download_space_cover(
         &self,
         space_id: String,
@@ -899,6 +919,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Like or unlike a post.
+    #[wasm_bindgen(js_name = likePost)]
     pub async fn like_post(
         &self,
         space_id: String,
@@ -909,6 +930,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Send a regular 1:1 message to a friend space.
+    #[wasm_bindgen(js_name = sendMessage)]
     pub async fn send_message(
         &self,
         sender_space_id: String,
@@ -927,6 +949,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Send a 1:1 reply to an existing message.
+    #[wasm_bindgen(js_name = replyToMessage)]
     pub async fn reply_to_message(
         &self,
         sender_space_id: String,
@@ -946,6 +969,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Send a private post reply message to the post owner.
+    #[wasm_bindgen(js_name = replyToPost)]
     pub async fn reply_to_post(
         &self,
         sender_space_id: String,
@@ -965,6 +989,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Like or unlike a message.
+    #[wasm_bindgen(js_name = likeMessage)]
     pub async fn like_message(
         &self,
         space_id: String,
@@ -981,6 +1006,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Delete a message sent by the current account.
+    #[wasm_bindgen(js_name = deleteMessage)]
     pub async fn delete_message(
         &self,
         space_id: String,
@@ -993,6 +1019,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// List current friends, pending requests, and latest chat summaries.
+    #[wasm_bindgen(js_name = listConversations)]
     pub async fn list_conversations(&self, space_id: String) -> Result<JsValue, WasmSpaceError> {
         let response = self.inner.list_conversations(&space_id).await?;
         let mut friends = Vec::with_capacity(response.friends.len());
@@ -1044,6 +1071,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// List a 1:1 message thread with decrypted messages.
+    #[wasm_bindgen(js_name = listMessageThread)]
     pub async fn list_message_thread(
         &self,
         viewer_space_id: String,
@@ -1069,6 +1097,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Update a post caption.
+    #[wasm_bindgen(js_name = updatePostCaption)]
     pub async fn update_post_caption(
         &self,
         space_id: String,
@@ -1095,6 +1124,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Delete a post.
+    #[wasm_bindgen(js_name = deletePost)]
     pub async fn delete_post(&self, space_id: String, post_id: i64) -> Result<(), WasmSpaceError> {
         self.inner
             .delete_post(&space_id, post_id)
@@ -1103,6 +1133,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// List friends for a space.
+    #[wasm_bindgen(js_name = listSpaceFriends)]
     pub async fn list_space_friends(&self, space_id: String) -> Result<JsValue, WasmSpaceError> {
         let friends = self.inner.list_space_friends(&space_id).await?;
         let mut items = Vec::with_capacity(friends.len());
@@ -1117,6 +1148,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// List incoming friend requests for the current account.
+    #[wasm_bindgen(js_name = listFriendRequests)]
     pub async fn list_friend_requests(&self, space_id: String) -> Result<JsValue, WasmSpaceError> {
         let requests = self.inner.list_friend_requests(&space_id).await?;
         let mut items = Vec::with_capacity(requests.len());
@@ -1131,6 +1163,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Confirm an incoming friend request.
+    #[wasm_bindgen(js_name = confirmFriendRequest)]
     pub async fn confirm_friend_request(
         &self,
         space_id: String,
@@ -1146,6 +1179,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Delete an incoming friend request.
+    #[wasm_bindgen(js_name = deleteFriendRequest)]
     pub async fn delete_friend_request(
         &self,
         space_id: String,
@@ -1158,6 +1192,7 @@ impl SpaceAccountCtxHandle {
     }
 
     /// Remove a friend by their space ID.
+    #[wasm_bindgen(js_name = removeFriendBySpace)]
     pub async fn remove_friend_by_space(
         &self,
         actor_space_id: String,
@@ -1170,11 +1205,13 @@ impl SpaceAccountCtxHandle {
     }
 
     /// List friend shares available to the current account.
+    #[wasm_bindgen(js_name = listFriendShares)]
     pub async fn list_friend_shares(&self, space_id: String) -> Result<JsValue, WasmSpaceError> {
         swb::to_value(&self.inner.list_friend_shares(&space_id).await?).map_err(Into::into)
     }
 
     /// Refresh friend shares for a rotated space key.
+    #[wasm_bindgen(js_name = refreshFriendShares)]
     pub async fn refresh_friend_shares(&self, space_id: String) -> Result<usize, WasmSpaceError> {
         self.inner
             .refresh_friend_shares(&space_id)

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -19,4 +19,5 @@ apps/ensu/next/
 
 # Generated wasm build
 packages/wasm/pkg/
+packages/wasm/space/pkg/
 packages/wasm-core/pkg/

--- a/web/.prettierignore
+++ b/web/.prettierignore
@@ -1,4 +1,5 @@
 package-lock.json
 packages/wasm/pkg-srp/**
 packages/wasm/pkg/**
+packages/wasm/space/pkg/**
 packages/wasm/target/**

--- a/web/apps/space/next.config.js
+++ b/web/apps/space/next.config.js
@@ -3,7 +3,11 @@ const baseConfig = require("ente-base/next.config.base.js");
 module.exports = {
     ...baseConfig,
     transpilePackages: Array.from(
-        new Set([...(baseConfig.transpilePackages || []), "ente-media"]),
+        new Set([
+            ...(baseConfig.transpilePackages || []),
+            "ente-media",
+            "ente-space-wasm",
+        ]),
     ),
     // Static deployments serve arbitrary profile links through profile-link.html.
     // In development, mirror that behavior with fallback rewrites.

--- a/web/apps/space/package.json
+++ b/web/apps/space/package.json
@@ -13,6 +13,7 @@
         "ente-accounts-rs": "*",
         "ente-base": "*",
         "ente-media": "*",
+        "ente-space-wasm": "*",
         "ente-wasm": "*",
         "ente-wasm-core": "*",
         "photoswipe": "5.4.4",

--- a/web/apps/space/src/components/ConfirmationActionSheet.tsx
+++ b/web/apps/space/src/components/ConfirmationActionSheet.tsx
@@ -14,7 +14,7 @@ interface ConfirmationActionSheetProps {
     appearance?: "light" | "dark";
     open: boolean;
     title: string;
-    description?: string;
+    description?: React.ReactNode;
     confirmLabel: string;
     confirmBackgroundColor?: string;
     confirmActionPhase?: SpaceActionPhase | null;

--- a/web/apps/space/src/screens/SettingsScreen.tsx
+++ b/web/apps/space/src/screens/SettingsScreen.tsx
@@ -378,7 +378,13 @@ export const SettingsScreen: React.FC<SettingsScreenProps> = ({
             <ConfirmationActionSheet
                 open={logoutSheetOpen}
                 title="Log out of Space?"
-                description="This will also log you out of Space on any other devices."
+                description={
+                    <>
+                        This will also log you out of Space on
+                        <br />
+                        any other devices.
+                    </>
+                }
                 confirmLabel="Yes, logout"
                 confirmActionPhase={logoutActionPhase}
                 confirmDisabled={isLogoutRunning}

--- a/web/apps/space/src/services/space.ts
+++ b/web/apps/space/src/services/space.ts
@@ -1,6 +1,6 @@
 import type { FriendProfile } from "data/friends";
 import { apiOrigin } from "ente-base/origins";
-import type { SpaceAccountCtxHandle } from "ente-wasm";
+import type { SpaceAccountCtxHandle } from "ente-space-wasm";
 import type { PendingSpaceInvite } from "services/spaceInvite";
 import {
     cachedSpaceMediaBlobURL,
@@ -293,22 +293,22 @@ interface SpaceUnreadStatusResponse {
 }
 
 interface SpaceFriendRequestContext {
-    confirm_friend_request: (
+    confirmFriendRequest: (
         spaceId: string,
         requestId: bigint,
     ) => Promise<unknown>;
-    delete_friend_request: (
+    deleteFriendRequest: (
         spaceId: string,
         requestId: bigint,
     ) => Promise<void>;
-    request_friend_by_username: (
+    requestFriendByUsername: (
         spaceId: string,
         username: string,
     ) => Promise<unknown>;
 }
 
 interface SpaceConversationsContext {
-    list_conversations: (
+    listConversations: (
         spaceId: string,
     ) => Promise<SpaceConversationsResponse>;
 }
@@ -425,7 +425,7 @@ const accountCoverURL = async (
                 cover.keyVersion,
             ),
             () =>
-                ctx.download_space_cover(
+                ctx.downloadSpaceCover(
                     spaceId,
                     viewerSpaceId ?? null,
                     cover.objectID,
@@ -454,7 +454,7 @@ const accountAvatarURL = async (
                 avatar.keyVersion,
             ),
             () =>
-                ctx.download_space_avatar(
+                ctx.downloadSpaceAvatar(
                     spaceId,
                     viewerSpaceId ?? null,
                     avatar.objectID,
@@ -490,7 +490,7 @@ const accountPostAssetURLFromAsset = (
     cachedSpaceMediaBlobURL(
         postAssetCacheKey(asset),
         () =>
-            ctx.download_post_asset_with_key(
+            ctx.downloadPostAssetWithKey(
                 asset.spaceId,
                 asset.encryptedPostKey,
                 asset.keyVersion,
@@ -668,7 +668,7 @@ const messageQuoteFromReplyPost = async (
     if (!includeImage) return fallbackQuote;
 
     try {
-        const post = (await ctx.get_post(
+        const post = (await ctx.getPost(
             message.recipientSpaceId,
             BigInt(message.replyPostId),
             viewerSpaceId ?? null,
@@ -801,7 +801,7 @@ export const joinSpaceInvite = async ({
     try {
         const response = (await (
             ctx as SpaceFriendRequestContext
-        ).request_friend_by_username(spaceId, spaceUsername)) as {
+        ).requestFriendByUsername(spaceId, spaceUsername)) as {
             status?: string;
         };
         return response.status == "friend" ? "friend" : "requested";
@@ -831,7 +831,7 @@ export const loadCurrentSpaceFriends = async (spaceId: string) => {
 
     const ctx = await ensureCurrentSpaceContext();
     const promise = (async () => {
-        const friends = (await ctx.list_space_friends(
+        const friends = (await ctx.listSpaceFriends(
             spaceId,
         )) as SpaceFriend[];
         return friends.map(({ friend }) => actorProfile(friend));
@@ -853,7 +853,7 @@ export const loadCurrentSpaceFriends = async (spaceId: string) => {
 export const loadCurrentSpaceFriendsCount = async (spaceId: string) => {
     const ctx = await ensureCurrentSpaceContext();
     try {
-        const spaceProfile = (await ctx.get_space_profile(
+        const spaceProfile = (await ctx.getSpaceProfile(
             spaceId,
             spaceId,
         )) as SpaceProfileResponse;
@@ -869,7 +869,7 @@ export const loadCurrentSpaceProfile = async (
 ): Promise<FriendProfile> => {
     const ctx = await ensureCurrentSpaceContext();
     try {
-        const spaceProfile = (await ctx.get_space_profile(
+        const spaceProfile = (await ctx.getSpaceProfile(
             spaceId,
             viewerSpaceId ?? null,
         )) as SpaceProfileResponse;
@@ -902,7 +902,7 @@ export const removeCurrentSpaceFriend = async (
 ) => {
     const ctx = await ensureCurrentSpaceContext();
     try {
-        await ctx.remove_friend_by_space(actorSpaceId, spaceId);
+        await ctx.removeFriendBySpace(actorSpaceId, spaceId);
         clearSpaceFriendsCache();
     } finally {
         releaseCurrentSpaceContext(ctx);
@@ -917,7 +917,7 @@ export const loadCurrentFeedPage = async (
     try {
         return await postPageFromAccountPage(
             ctx,
-            (await ctx.list_feed(
+            (await ctx.listFeed(
                 spaceId,
                 cursor ?? null,
                 currentFeedPageSize,
@@ -935,7 +935,7 @@ export const loadCurrentUnreadStatus = async (
 ): Promise<SpaceUnreadStatus> => {
     const ctx = await ensureCurrentSpaceContext();
     try {
-        const status = (await ctx.unread_status(
+        const status = (await ctx.unreadStatus(
             spaceId,
         )) as SpaceUnreadStatusResponse;
         return { messagesUnread: status.notificationsUnread };
@@ -952,7 +952,7 @@ export const loadCurrentSpaceProfilePostsPage = async (
     const ctx = await ensureCurrentSpaceContext();
     try {
         return profilePostPageFromPage(
-            (await ctx.list_posts(
+            (await ctx.listPosts(
                 spaceId,
                 viewerSpaceId ?? null,
                 cursor ?? null,
@@ -971,7 +971,7 @@ export const loadCurrentSpacePost = async (
 ): Promise<SpacePost | null> => {
     const ctx = await ensureCurrentSpaceContext();
     try {
-        const response = (await ctx.get_post(
+        const response = (await ctx.getPost(
             spaceId,
             BigInt(postId),
             viewerSpaceId ?? null,
@@ -1073,7 +1073,7 @@ export const createCurrentPhotoPost = async ({
         const bytes = new Uint8Array(await file.arrayBuffer());
         const normalizedWidth = normalizedImageDimension(width);
         const normalizedHeight = normalizedImageDimension(height);
-        const created = (await ctx.create_photo_post(
+        const created = (await ctx.createPhotoPost(
             spaceId,
             bytes,
             caption?.trim() || null,
@@ -1109,7 +1109,7 @@ export const setCurrentPostLiked = async (
 ) => {
     const ctx = await ensureCurrentSpaceContext();
     try {
-        await ctx.like_post(spaceId, BigInt(postId), liked);
+        await ctx.likePost(spaceId, BigInt(postId), liked);
     } finally {
         releaseCurrentSpaceContext(ctx);
     }
@@ -1124,7 +1124,7 @@ export const replyToCurrentPost = async (
     const messageText = normalizeSpaceMessageText(text);
     const ctx = await ensureCurrentSpaceContext();
     try {
-        await ctx.reply_to_post(
+        await ctx.replyToPost(
             actorSpaceId,
             postSpaceId,
             BigInt(postId),
@@ -1147,7 +1147,7 @@ export const sendCurrentMessage = async (
     try {
         return await messageFromSpaceMessage(
             ctx,
-            (await ctx.send_message(
+            (await ctx.sendMessage(
                 senderSpaceId,
                 spaceId,
                 messageText,
@@ -1174,7 +1174,7 @@ export const replyToCurrentMessage = async (
     try {
         return await messageFromSpaceMessage(
             ctx,
-            (await ctx.reply_to_message(
+            (await ctx.replyToMessage(
                 senderSpaceId,
                 spaceId,
                 messageId,
@@ -1196,7 +1196,7 @@ export const setCurrentMessageLiked = async (
 ) => {
     const ctx = await ensureCurrentSpaceContext();
     try {
-        await ctx.like_message(spaceId, messageId, liked);
+        await ctx.likeMessage(spaceId, messageId, liked);
     } finally {
         releaseCurrentSpaceContext(ctx);
     }
@@ -1208,7 +1208,7 @@ export const deleteCurrentMessage = async (
 ) => {
     const ctx = await ensureCurrentSpaceContext();
     try {
-        await ctx.delete_message(spaceId, messageId);
+        await ctx.deleteMessage(spaceId, messageId);
     } finally {
         releaseCurrentSpaceContext(ctx);
     }
@@ -1221,7 +1221,7 @@ export const loadCurrentMessageConversations = async (
     try {
         const response = await (
             ctx as unknown as SpaceConversationsContext
-        ).list_conversations(spaceId);
+        ).listConversations(spaceId);
         const summaries = response.chatSummaries;
         const friendItems = await Promise.all(
             (response.friends ?? []).map(async (conversation) => {
@@ -1292,7 +1292,7 @@ export const confirmCurrentFriendRequest = async (
 ) => {
     const ctx = await ensureCurrentSpaceContext();
     try {
-        await (ctx as SpaceFriendRequestContext).confirm_friend_request(
+        await (ctx as SpaceFriendRequestContext).confirmFriendRequest(
             spaceId,
             BigInt(requestId),
         );
@@ -1308,7 +1308,7 @@ export const deleteCurrentFriendRequest = async (
 ) => {
     const ctx = await ensureCurrentSpaceContext();
     try {
-        await (ctx as SpaceFriendRequestContext).delete_friend_request(
+        await (ctx as SpaceFriendRequestContext).deleteFriendRequest(
             spaceId,
             BigInt(requestId),
         );
@@ -1325,7 +1325,7 @@ export const loadCurrentMessageThread = async (
 ): Promise<SpaceMessagePage> => {
     const ctx = await ensureCurrentSpaceContext();
     try {
-        const page = (await ctx.list_message_thread(
+        const page = (await ctx.listMessageThread(
             viewerSpaceId,
             spaceId,
             null,
@@ -1354,7 +1354,7 @@ export const markCurrentMessagesRead = async (
     if (!friendSpaceId.trim()) return;
     const ctx = await ensureCurrentSpaceContext();
     try {
-        await ctx.mark_notifications_read(spaceId, friendSpaceId);
+        await ctx.markNotificationsRead(spaceId, friendSpaceId);
     } finally {
         releaseCurrentSpaceContext(ctx);
     }
@@ -1363,7 +1363,7 @@ export const markCurrentMessagesRead = async (
 export const deleteCurrentPost = async (spaceId: string, postId: number) => {
     const ctx = await ensureCurrentSpaceContext();
     try {
-        await ctx.delete_post(spaceId, BigInt(postId));
+        await ctx.deletePost(spaceId, BigInt(postId));
     } finally {
         releaseCurrentSpaceContext(ctx);
     }

--- a/web/apps/space/src/services/spaceProfile.ts
+++ b/web/apps/space/src/services/spaceProfile.ts
@@ -1,8 +1,7 @@
 import { savedPartialLocalUser } from "ente-accounts-rs/services/accounts-db";
 import { clientPackageName, desktopAppVersion, isDesktop } from "ente-base/app";
 import { apiOrigin, apiURL } from "ente-base/origins";
-import type { SpaceAccountCtxHandle } from "ente-wasm";
-import { loadEnteWasm } from "ente-wasm/load";
+import type { SpaceAccountCtxHandle } from "ente-space-wasm";
 import type {
     SetupProfile,
     SetupProfileInput,
@@ -158,8 +157,8 @@ export const openCurrentSpaceContext = async () => {
     const config = await currentSpaceContextConfig();
     if (!config) return undefined;
 
-    const { space_open_account_ctx } = await loadEnteWasm();
-    return await space_open_account_ctx(config.input);
+    const { spaceOpenAccountCtx } = await import("ente-space-wasm");
+    return await spaceOpenAccountCtx(config.input);
 };
 
 export const clearCurrentSpaceContext = () => {
@@ -190,8 +189,8 @@ export const ensureCurrentSpaceContext = async () => {
 
     const generation = currentSpaceContextGeneration;
     const promise = (async () => {
-        const { space_open_account_ctx } = await loadEnteWasm();
-        return await space_open_account_ctx(config.input);
+        const { spaceOpenAccountCtx } = await import("ente-space-wasm");
+        return await spaceOpenAccountCtx(config.input);
     })()
         .then((ctx) => {
             if (
@@ -235,7 +234,7 @@ const avatarURLForRemoteAvatar = async (
             avatar.keyVersion,
         ),
         () =>
-            ctx.download_space_avatar(
+            ctx.downloadSpaceAvatar(
                 spaceId,
                 spaceId,
                 avatar.objectID,
@@ -258,7 +257,7 @@ const coverURLForRemoteCover = async (
             cover.keyVersion,
         ),
         () =>
-            ctx.download_space_cover(
+            ctx.downloadSpaceCover(
                 spaceId,
                 spaceId,
                 cover.objectID,
@@ -307,11 +306,11 @@ export const loadExistingSpaceProfile = async (options?: {
 
     const promise = (async () => {
         const ctx = await ensureCurrentSpaceContext();
-        const spaces = (await ctx.list_owned_spaces()) as OwnedSpace[];
+        const spaces = (await ctx.listOwnedSpaces()) as OwnedSpace[];
         const space = defaultOwnedSpace(spaces);
         if (!space) return null;
 
-        const spaceProfile = (await ctx.get_space_profile(
+        const spaceProfile = (await ctx.getSpaceProfile(
             space.spaceId,
             space.spaceId,
         )) as DecryptedSpaceProfile;
@@ -400,7 +399,7 @@ export const saveSpaceProfile = async (
 
     const ctx = await ensureCurrentSpaceContext();
     try {
-        const spaces = (await ctx.list_owned_spaces()) as OwnedSpace[];
+        const spaces = (await ctx.listOwnedSpaces()) as OwnedSpace[];
         const existingSpace =
             (profile.spaceId &&
                 spaces.find((space) => space.spaceId == profile.spaceId)) ||
@@ -421,14 +420,14 @@ export const saveSpaceProfile = async (
             spaceId = existingSpace.spaceId;
             spaceSlug = existingSpace.spaceSlug;
             if (normalizeSpaceUsername(spaceSlug) != username) {
-                const updatedSlug = (await ctx.update_space_slug(
+                const updatedSlug = (await ctx.updateSpaceSlug(
                     spaceId,
                     username,
                 )) as SpaceLookup;
                 spaceSlug = updatedSlug.spaceSlug;
             }
         } else {
-            const created = (await ctx.create_space(
+            const created = (await ctx.createSpace(
                 username,
                 profilePayload,
                 referredBySpaceId?.trim() || undefined,
@@ -443,7 +442,7 @@ export const saveSpaceProfile = async (
             const avatarBytes = new Uint8Array(
                 await profile.avatarFile.arrayBuffer(),
             );
-            updateResponse = (await ctx.update_space_profile_with_avatar(
+            updateResponse = (await ctx.updateSpaceProfileWithAvatar(
                 spaceId,
                 profilePayload,
                 avatarBytes,
@@ -463,7 +462,7 @@ export const saveSpaceProfile = async (
             const coverBytes = new Uint8Array(
                 await profile.coverFile.arrayBuffer(),
             );
-            updateResponse = (await ctx.update_space_profile_with_cover(
+            updateResponse = (await ctx.updateSpaceProfileWithCover(
                 spaceId,
                 profilePayload,
                 coverBytes,
@@ -480,7 +479,7 @@ export const saveSpaceProfile = async (
                   )
                 : URL.createObjectURL(profile.coverFile);
         } else if (existingSpace) {
-            updateResponse = (await ctx.update_space_profile(
+            updateResponse = (await ctx.updateSpaceProfile(
                 spaceId,
                 profilePayload,
             )) as UpdateSpaceProfileResponse;

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,8 @@
             "version": "0.0.0",
             "workspaces": [
                 "apps/*",
-                "packages/*"
+                "packages/*",
+                "packages/wasm/space"
             ],
             "devDependencies": {
                 "concurrently": "10.0.3",
@@ -333,6 +334,7 @@
                 "ente-accounts-rs": "*",
                 "ente-base": "*",
                 "ente-media": "*",
+                "ente-space-wasm": "*",
                 "ente-wasm": "*",
                 "ente-wasm-core": "*",
                 "photoswipe": "5.4.4",
@@ -4621,6 +4623,10 @@
         },
         "node_modules/ente-new": {
             "resolved": "packages/new",
+            "link": true
+        },
+        "node_modules/ente-space-wasm": {
+            "resolved": "packages/wasm/space",
             "link": true
         },
         "node_modules/ente-utils": {
@@ -11288,6 +11294,14 @@
         },
         "packages/wasm-core": {
             "name": "ente-wasm-core",
+            "version": "0.0.0",
+            "devDependencies": {
+                "ente-build-config": "*",
+                "wasm-pack": "0.15.0"
+            }
+        },
+        "packages/wasm/space": {
+            "name": "ente-space-wasm",
             "version": "0.0.0",
             "devDependencies": {
                 "ente-build-config": "*",

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,8 @@
     "private": true,
     "workspaces": [
         "apps/*",
-        "packages/*"
+        "packages/*",
+        "packages/wasm/space"
     ],
     "scripts": {
         "build": "npm run build:photos",
@@ -21,7 +22,8 @@
         "build:payments": "npm run build --workspace payments",
         "build:photos": "npm run build:wasm && npm exec --workspace photos -- next build --webpack",
         "build:share": "npm run build:wasm && npm exec --workspace share -- next build --webpack && npm run build:post --workspace share",
-        "build:space": "npm run build:wasm && npm exec --workspace space -- next build --webpack && npm run build:post --workspace space",
+        "build:space": "npm run build:wasm && npm run build:space-wasm && npm exec --workspace space -- next build --webpack && npm run build:post --workspace space",
+        "build:space-wasm": "npm run build --workspace ente-space-wasm -- --no-pack",
         "build:twoof3": "npm exec --workspace twoof3 -- next build --webpack",
         "build:wasm": "npm run build --workspace ente-wasm -- --no-pack && npm run build --workspace ente-wasm-core -- --no-pack",
         "dev": "npm run dev:photos",
@@ -38,7 +40,7 @@
         "dev:payments": "npm run dev --workspace payments",
         "dev:photos": "npm run build:wasm && npm exec --workspace photos -- next dev --webpack -p 3000",
         "dev:share": "npm run build:wasm && npm exec --workspace share -- next dev --webpack -p 3005",
-        "dev:space": "npm run build:wasm && npm exec --workspace space -- next dev --webpack -p 3013",
+        "dev:space": "npm run build:wasm && npm run build:space-wasm && npm exec --workspace space -- next dev --webpack -p 3013",
         "dev:twoof3": "npm exec --workspace twoof3 -- next dev --webpack -p 3012",
         "lint": "concurrently --names 'prettier,eslint,tsc' \"prettier --check --log-level warn .\" \"npm exec --workspaces -- eslint\" \"npm exec --workspaces -- tsc\"",
         "lint:fix": "concurrently --names 'prettier,eslint,tsc' \"prettier --write --log-level warn .\" \"npm exec --workspaces -- eslint --fix\" \"npm exec --workspaces -- tsc\"",

--- a/web/packages/wasm/eslint.config.mjs
+++ b/web/packages/wasm/eslint.config.mjs
@@ -1,3 +1,3 @@
 import config from "ente-build-config/eslintrc-base.mjs";
 
-export default [...config, { ignores: ["pkg/", "pkg-srp/"] }];
+export default [...config, { ignores: ["pkg/", "pkg-srp/", "space/"] }];

--- a/web/packages/wasm/space/eslint.config.mjs
+++ b/web/packages/wasm/space/eslint.config.mjs
@@ -1,0 +1,3 @@
+import config from "ente-build-config/eslintrc-base.mjs";
+
+export default [...config, { ignores: ["pkg/"] }];

--- a/web/packages/wasm/space/index.ts
+++ b/web/packages/wasm/space/index.ts
@@ -1,0 +1,1 @@
+export * from "./pkg/ente_space_wasm";

--- a/web/packages/wasm/space/package.json
+++ b/web/packages/wasm/space/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "ente-space-wasm",
+    "version": "0.0.0",
+    "private": true,
+    "exports": {
+        ".": {
+            "types": "./index.ts",
+            "import": "./index.ts"
+        }
+    },
+    "module": "./index.ts",
+    "types": "./index.ts",
+    "scripts": {
+        "build": "wasm-pack build ../../../../rust/bindings/wasm/space --target bundler --out-dir ../../../../web/packages/wasm/space/pkg"
+    },
+    "devDependencies": {
+        "ente-build-config": "*",
+        "wasm-pack": "0.15.0"
+    }
+}

--- a/web/packages/wasm/space/tsconfig.json
+++ b/web/packages/wasm/space/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "ente-build-config/tsconfig-typecheck.json", "include": ["."] }

--- a/web/packages/wasm/tsconfig.json
+++ b/web/packages/wasm/tsconfig.json
@@ -1,1 +1,5 @@
-{ "extends": "ente-build-config/tsconfig-typecheck.json", "include": ["."] }
+{
+    "extends": "ente-build-config/tsconfig-typecheck.json",
+    "include": ["."],
+    "exclude": ["space"]
+}


### PR DESCRIPTION
Move Space bindings out of ente-wasm into a dedicated ente-space-wasm Rust crate and web workspace package. Update the Space app to use its camelCase exports, and compile the package in local builds and web CI.